### PR TITLE
Fix session refinement grounding and exclusions

### DIFF
--- a/orchestrators/k8s/terraform/README.md
+++ b/orchestrators/k8s/terraform/README.md
@@ -74,8 +74,8 @@ task clean
 | `kafka_password` | `string` | — | Kafka password (sensitive) |
 | `rabbitmq_password` | `string` | — | RabbitMQ password (sensitive) |
 | `rabbitmq_admin_password` | `string` | `null` | Optional RabbitMQ admin password. Falls back to `rabbitmq_password` when unset |
-| `agent_service_provider` | `string` | `"nvidia_nim"` | Kino Agent Service model provider |
-| `agent_service_model` | `string` | `"deepseek-ai/deepseek-v3.2"` | Kino Agent Service model |
+| `agent_service_provider` | `string` | `"google_genai"` | Kino Agent Service model provider |
+| `agent_service_model` | `string` | `"gemini-3.1-flash-lite-preview"` | Kino Agent Service model |
 | `nvidia_api_key` | `string` | `null` | NVIDIA API key for Kino Agent Service |
 | `agent_service_client_secret` | `string` | `"replace-me-agent-secret"` | Auth-service client secret for agent-service machine tokens |
 

--- a/orchestrators/k8s/terraform/terraform.tfvars.example
+++ b/orchestrators/k8s/terraform/terraform.tfvars.example
@@ -18,5 +18,5 @@ enable_grafana            = true
 enable_ingress            = true
 
 # Agent Service
-agent_service_provider = "nvidia_nim"
-agent_service_model    = "deepseek-ai/deepseek-v3.2"
+agent_service_provider = "google_genai"
+agent_service_model    = "gemini-3.1-flash-lite-preview"

--- a/orchestrators/k8s/terraform/variables.tf
+++ b/orchestrators/k8s/terraform/variables.tf
@@ -141,7 +141,7 @@ variable "rabbitmq_admin_password" {
 variable "agent_service_provider" {
   type        = string
   description = "Kino Agent Service model provider"
-  default     = "nvidia_nim"
+  default     = "google_genai"
 
   validation {
     condition = contains(
@@ -155,7 +155,7 @@ variable "agent_service_provider" {
 variable "agent_service_model" {
   type        = string
   description = "Kino Agent Service model name"
-  default     = "deepseek-ai/deepseek-v3.2"
+  default     = "gemini-3.1-flash-lite-preview"
 }
 
 variable "nvidia_api_key" {

--- a/services/langgraph/agent_service/src/agent_service/data_service.py
+++ b/services/langgraph/agent_service/src/agent_service/data_service.py
@@ -11,6 +11,34 @@ MAX_EXCLUSION_SEARCH_PAGES = 5
 
 
 @dataclass(frozen=True)
+class TitleSearchRequest:
+    """Normalized input for a single title search."""
+
+    free_text: str | None
+    genres: list[str] | None
+    title_type: str | None
+    min_year: int | None
+    max_year: int | None
+    exclude_ids: list[str] | None
+    is_adult: bool
+    size: int
+
+    @property
+    def requested_size(self) -> int:
+        """Return the bounded page size for this search."""
+        return min(max(self.size, 1), 12)
+
+    @property
+    def excluded_ids(self) -> set[str]:
+        """Return normalized IDs that should be excluded."""
+        return {
+            str(title_id)
+            for title_id in (self.exclude_ids or [])
+            if title_id not in (None, "")
+        }
+
+
+@dataclass(frozen=True)
 class MachineAccessTokenClient:
     """Client for Kino auth service client-credentials tokens."""
 
@@ -54,75 +82,26 @@ class KinoDataServiceClient:
 
     async def search_titles(
         self,
-        free_text: str | None,
-        genres: list[str] | None,
-        title_type: str | None,
-        min_year: int | None,
-        max_year: int | None,
-        exclude_ids: list[str] | None,
-        is_adult: bool,
-        size: int,
+        search: TitleSearchRequest,
     ) -> list[dict[str, Any]]:
         """Search titles and return compact catalog records."""
         if not self.base_url:
             return [{"error": "KINO_DATA_SERVICE_URL is not configured."}]
 
-        requested_size = min(max(size, 1), 12)
-        excluded_ids = {
-            str(title_id)
-            for title_id in (exclude_ids or [])
-            if title_id not in (None, "")
-        }
-
         try:
             headers = await self._authorization_header()
             async with httpx.AsyncClient(timeout=5.0) as client:
-                if not excluded_ids:
-                    titles, _ = await self._fetch_titles_page(
+                if not search.excluded_ids:
+                    return await self._search_first_page(
                         client,
                         headers=headers,
-                        free_text=free_text,
-                        genres=genres,
-                        title_type=title_type,
-                        min_year=min_year,
-                        max_year=max_year,
-                        is_adult=is_adult,
-                        page=0,
-                        size=requested_size,
+                        search=search,
                     )
-                    return titles[:requested_size]
-
-                collected: list[dict[str, Any]] = []
-                seen_ids = set(excluded_ids)
-                page = 0
-                while (
-                    len(collected) < requested_size
-                    and page < MAX_EXCLUSION_SEARCH_PAGES
-                ):
-                    titles, is_last = await self._fetch_titles_page(
-                        client,
-                        headers=headers,
-                        free_text=free_text,
-                        genres=genres,
-                        title_type=title_type,
-                        min_year=min_year,
-                        max_year=max_year,
-                        is_adult=is_adult,
-                        page=page,
-                        size=12,
-                    )
-                    for title in titles:
-                        title_id = str(title.get("id") or "")
-                        if title_id and title_id in seen_ids:
-                            continue
-                        if title_id:
-                            seen_ids.add(title_id)
-                        collected.append(title)
-                        if len(collected) >= requested_size:
-                            break
-                    if is_last:
-                        break
-                    page += 1
+                return await self._search_titles_with_exclusions(
+                    client,
+                    headers=headers,
+                    search=search,
+                )
         except ValueError as exc:
             return [
                 {
@@ -135,34 +114,27 @@ class KinoDataServiceClient:
         except httpx.HTTPError as exc:
             return [{"error": f"Failed to query Kino data service: {exc}"}]
 
-        return collected[:requested_size]
-
     @staticmethod
     def _search_params(
-        free_text: str | None,
-        genres: list[str] | None,
-        title_type: str | None,
-        min_year: int | None,
-        max_year: int | None,
-        is_adult: bool,
+        search: TitleSearchRequest,
         page: int,
         size: int,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
-            "isAdult": str(is_adult).lower(),
+            "isAdult": str(search.is_adult).lower(),
             "page": max(page, 0),
             "size": min(max(size, 1), 12),
         }
-        if free_text:
-            params["freeText"] = free_text
-        if genres:
-            params["genres"] = genres
-        if title_type:
-            params["titleType"] = title_type
-        if min_year is not None:
-            params["minYear"] = min_year
-        if max_year is not None:
-            params["maxYear"] = max_year
+        if search.free_text:
+            params["freeText"] = search.free_text
+        if search.genres:
+            params["genres"] = search.genres
+        if search.title_type:
+            params["titleType"] = search.title_type
+        if search.min_year is not None:
+            params["minYear"] = search.min_year
+        if search.max_year is not None:
+            params["maxYear"] = search.max_year
         return params
 
     async def _authorization_header(self) -> dict[str, str]:
@@ -179,22 +151,12 @@ class KinoDataServiceClient:
         client: httpx.AsyncClient,
         *,
         headers: dict[str, str],
-        free_text: str | None,
-        genres: list[str] | None,
-        title_type: str | None,
-        min_year: int | None,
-        max_year: int | None,
-        is_adult: bool,
+        search: TitleSearchRequest,
         page: int,
         size: int,
     ) -> tuple[list[dict[str, Any]], bool]:
         params = self._search_params(
-            free_text=free_text,
-            genres=genres,
-            title_type=title_type,
-            min_year=min_year,
-            max_year=max_year,
-            is_adult=is_adult,
+            search=search,
             page=page,
             size=size,
         )
@@ -222,6 +184,57 @@ class KinoDataServiceClient:
             if isinstance(page_number, int) and isinstance(total_pages, int):
                 return titles, page_number + 1 >= total_pages
         return titles, len(content) < params["size"]
+
+    async def _search_first_page(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        headers: dict[str, str],
+        search: TitleSearchRequest,
+    ) -> list[dict[str, Any]]:
+        titles, _ = await self._fetch_titles_page(
+            client,
+            headers=headers,
+            search=search,
+            page=0,
+            size=search.requested_size,
+        )
+        return titles[: search.requested_size]
+
+    async def _search_titles_with_exclusions(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        headers: dict[str, str],
+        search: TitleSearchRequest,
+    ) -> list[dict[str, Any]]:
+        collected: list[dict[str, Any]] = []
+        seen_ids = set(search.excluded_ids)
+        page = 0
+        while (
+            len(collected) < search.requested_size
+            and page < MAX_EXCLUSION_SEARCH_PAGES
+        ):
+            titles, is_last = await self._fetch_titles_page(
+                client,
+                headers=headers,
+                search=search,
+                page=page,
+                size=12,
+            )
+            for title in titles:
+                title_id = str(title.get("id") or "")
+                if title_id and title_id in seen_ids:
+                    continue
+                if title_id:
+                    seen_ids.add(title_id)
+                collected.append(title)
+                if len(collected) >= search.requested_size:
+                    break
+            if is_last:
+                break
+            page += 1
+        return collected[: search.requested_size]
 
 
 class TitleCompactor:

--- a/services/langgraph/agent_service/src/agent_service/data_service.py
+++ b/services/langgraph/agent_service/src/agent_service/data_service.py
@@ -81,8 +81,7 @@ class KinoDataServiceClient:
     auth_client_secret: str
 
     async def search_titles(
-        self,
-        search: TitleSearchRequest,
+        self, search: TitleSearchRequest
     ) -> list[dict[str, Any]]:
         """Search titles and return compact catalog records."""
         if not self.base_url:
@@ -93,14 +92,10 @@ class KinoDataServiceClient:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 if not search.excluded_ids:
                     return await self._search_first_page(
-                        client,
-                        headers=headers,
-                        search=search,
+                        client, headers=headers, search=search
                     )
                 return await self._search_titles_with_exclusions(
-                    client,
-                    headers=headers,
-                    search=search,
+                    client, headers=headers, search=search
                 )
         except ValueError as exc:
             return [
@@ -116,9 +111,7 @@ class KinoDataServiceClient:
 
     @staticmethod
     def _search_params(
-        search: TitleSearchRequest,
-        page: int,
-        size: int,
+        search: TitleSearchRequest, page: int, size: int
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
             "isAdult": str(search.is_adult).lower(),
@@ -155,11 +148,7 @@ class KinoDataServiceClient:
         page: int,
         size: int,
     ) -> tuple[list[dict[str, Any]], bool]:
-        params = self._search_params(
-            search=search,
-            page=page,
-            size=size,
-        )
+        params = self._search_params(search=search, page=page, size=size)
         response = await client.get(
             f"{self.base_url}/internal/titles/search",
             params=params,
@@ -216,11 +205,7 @@ class KinoDataServiceClient:
             and page < MAX_EXCLUSION_SEARCH_PAGES
         ):
             titles, is_last = await self._fetch_titles_page(
-                client,
-                headers=headers,
-                search=search,
-                page=page,
-                size=12,
+                client, headers=headers, search=search, page=page, size=12
             )
             for title in titles:
                 title_id = str(title.get("id") or "")

--- a/services/langgraph/agent_service/src/agent_service/data_service.py
+++ b/services/langgraph/agent_service/src/agent_service/data_service.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import httpx
 
+MAX_EXCLUSION_SEARCH_PAGES = 5
+
 
 @dataclass(frozen=True)
 class MachineAccessTokenClient:
@@ -57,6 +59,7 @@ class KinoDataServiceClient:
         title_type: str | None,
         min_year: int | None,
         max_year: int | None,
+        exclude_ids: list[str] | None,
         is_adult: bool,
         size: int,
     ) -> list[dict[str, Any]]:
@@ -64,25 +67,62 @@ class KinoDataServiceClient:
         if not self.base_url:
             return [{"error": "KINO_DATA_SERVICE_URL is not configured."}]
 
-        params = self._search_params(
-            free_text=free_text,
-            genres=genres,
-            title_type=title_type,
-            min_year=min_year,
-            max_year=max_year,
-            is_adult=is_adult,
-            size=size,
-        )
+        requested_size = min(max(size, 1), 12)
+        excluded_ids = {
+            str(title_id)
+            for title_id in (exclude_ids or [])
+            if title_id not in (None, "")
+        }
 
         try:
             headers = await self._authorization_header()
             async with httpx.AsyncClient(timeout=5.0) as client:
-                response = await client.get(
-                    f"{self.base_url}/internal/titles/search",
-                    params=params,
-                    headers=headers,
-                )
-                response.raise_for_status()
+                if not excluded_ids:
+                    titles, _ = await self._fetch_titles_page(
+                        client,
+                        headers=headers,
+                        free_text=free_text,
+                        genres=genres,
+                        title_type=title_type,
+                        min_year=min_year,
+                        max_year=max_year,
+                        is_adult=is_adult,
+                        page=0,
+                        size=requested_size,
+                    )
+                    return titles[:requested_size]
+
+                collected: list[dict[str, Any]] = []
+                seen_ids = set(excluded_ids)
+                page = 0
+                while (
+                    len(collected) < requested_size
+                    and page < MAX_EXCLUSION_SEARCH_PAGES
+                ):
+                    titles, is_last = await self._fetch_titles_page(
+                        client,
+                        headers=headers,
+                        free_text=free_text,
+                        genres=genres,
+                        title_type=title_type,
+                        min_year=min_year,
+                        max_year=max_year,
+                        is_adult=is_adult,
+                        page=page,
+                        size=12,
+                    )
+                    for title in titles:
+                        title_id = str(title.get("id") or "")
+                        if title_id and title_id in seen_ids:
+                            continue
+                        if title_id:
+                            seen_ids.add(title_id)
+                        collected.append(title)
+                        if len(collected) >= requested_size:
+                            break
+                    if is_last:
+                        break
+                    page += 1
         except ValueError as exc:
             return [
                 {
@@ -95,14 +135,7 @@ class KinoDataServiceClient:
         except httpx.HTTPError as exc:
             return [{"error": f"Failed to query Kino data service: {exc}"}]
 
-        payload = response.json()
-        content = payload.get(
-            "content", payload if isinstance(payload, list) else []
-        )
-        return [
-            TitleCompactor.compact(title)
-            for title in content[: params["size"]]
-        ]
+        return collected[:requested_size]
 
     @staticmethod
     def _search_params(
@@ -112,11 +145,12 @@ class KinoDataServiceClient:
         min_year: int | None,
         max_year: int | None,
         is_adult: bool,
+        page: int,
         size: int,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
             "isAdult": str(is_adult).lower(),
-            "page": 0,
+            "page": max(page, 0),
             "size": min(max(size, 1), 12),
         }
         if free_text:
@@ -139,6 +173,55 @@ class KinoDataServiceClient:
         )
         access_token = await token_client.issue_token()
         return {"Authorization": f"Bearer {access_token}"}
+
+    async def _fetch_titles_page(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        headers: dict[str, str],
+        free_text: str | None,
+        genres: list[str] | None,
+        title_type: str | None,
+        min_year: int | None,
+        max_year: int | None,
+        is_adult: bool,
+        page: int,
+        size: int,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        params = self._search_params(
+            free_text=free_text,
+            genres=genres,
+            title_type=title_type,
+            min_year=min_year,
+            max_year=max_year,
+            is_adult=is_adult,
+            page=page,
+            size=size,
+        )
+        response = await client.get(
+            f"{self.base_url}/internal/titles/search",
+            params=params,
+            headers=headers,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        content = payload.get(
+            "content", payload if isinstance(payload, list) else []
+        )
+        titles = [
+            TitleCompactor.compact(title)
+            for title in content[: params["size"]]
+        ]
+        if isinstance(payload, list):
+            return titles, True
+        if isinstance(payload, dict):
+            if isinstance(payload.get("last"), bool):
+                return titles, payload["last"]
+            page_number = payload.get("number")
+            total_pages = payload.get("totalPages")
+            if isinstance(page_number, int) and isinstance(total_pages, int):
+                return titles, page_number + 1 >= total_pages
+        return titles, len(content) < params["size"]
 
 
 class TitleCompactor:

--- a/services/langgraph/agent_service/src/agent_service/graph.py
+++ b/services/langgraph/agent_service/src/agent_service/graph.py
@@ -17,12 +17,16 @@ You are Kino Discover. Help the user discover titles from Kino's local catalog.
 # Tool policy
 Use `search_titles` for discovery requests unless the user is only asking
 how you work.
+Treat follow-up turns in the same thread as refinements of the current discovery
+context.
 Call `search_titles` exactly once, with the most specific supported
 constraints.
 After that search, stop searching and answer only from the grounded results.
 Do not retry, broaden, or reformulate the search inside the same request.
 
 # Search argument mapping
+- Carry forward supported search constraints from the current thread unless the
+  user explicitly overrides or clears them.
 - Use `title_type` only when the user asked for a specific format.
 - Use `genres` when the user asked for specific genres.
 - Use `min_year` for explicit lower bounds like "from 1990 onward".
@@ -30,6 +34,11 @@ Do not retry, broaden, or reformulate the search inside the same request.
 - Use both `min_year` and `max_year` for bounded ranges like
   "between 1990 and 2000" or "from 1990 to 2000".
 - Keep `is_adult` false unless the user explicitly asks for adult titles.
+- Use `exclude_ids` only when the user explicitly rejects titles already shown
+  in the current thread, such as "not those", "different ones", or "anything
+  but these".
+- If you use `exclude_ids` on a refinement turn, prefer `size=12` so Kino can
+  search for fresh unseen results in this turn.
 
 # Output policy
 Suggest only returned titles.
@@ -37,6 +46,7 @@ If the user asked for preferences the tool cannot enforce directly, such as
 popularity, accessibility, tone, or "general audience", do not pretend those
 filters were enforced. Answer from the grounded matches and mention the
 limitation plainly when it matters.
+Do not infer durable tastes or hidden preferences that the user did not state.
 Do not invent titles, IDs, years, genres, runtime data, plots, ratings, or
 popularity signals.
 Return a short natural-language discovery summary after tool use.

--- a/services/langgraph/agent_service/src/agent_service/middleware.py
+++ b/services/langgraph/agent_service/src/agent_service/middleware.py
@@ -9,12 +9,17 @@ from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from typing_extensions import TypedDict
 
-from agent_service.models import CuratorResponse, CuratorTitle
+from agent_service.models import (
+    CuratorActiveContext,
+    CuratorResponse,
+    CuratorTitle,
+)
 
 
 class SearchSnapshot(TypedDict):
     """Typed snapshot of the latest grounded search results."""
 
+    searched: bool
     candidates: list[dict[str, Any]]
     error: str | None
     args: dict[str, Any] | None
@@ -73,20 +78,27 @@ class CuratorResponseBuilder:
     def finalize_agent_state(cls, state: dict[str, Any]) -> CuratorResponse:
         """Build a grounded structured response from the final agent state."""
         snapshot = cls.latest_search_snapshot(state.get("messages", []))
+        active_context = cls.active_context_from_args(snapshot["args"])
+        if not snapshot["searched"]:
+            return CuratorResponse(activeContext=active_context)
         if snapshot["error"]:
-            return CuratorResponse(notes=[snapshot["error"]])
+            return CuratorResponse(
+                notes=[snapshot["error"]], activeContext=active_context
+            )
         candidates, notes = cls.apply_request_filters(
             snapshot["candidates"], snapshot["args"]
         )
         if not candidates:
             return CuratorResponse(
+                activeContext=active_context,
                 notes=notes
                 or [
                     "The catalog search did not return any grounded candidates."
-                ]
+                ],
             )
         response = cls.fallback_response(candidates)
         response.notes = [*notes, *response.notes][:3]
+        response.activeContext = active_context
         return response
 
     @staticmethod
@@ -100,40 +112,57 @@ class CuratorResponseBuilder:
 
     @classmethod
     def latest_search_snapshot(cls, messages: list[Any]) -> SearchSnapshot:
-        """Return the latest successful search result from the message list."""
-        last_error: str | None = None
-        for index in range(len(messages) - 1, -1, -1):
-            raw_message = messages[index]
+        """Return the latest search result from the current turn."""
+        turn_messages = cls.latest_turn_messages(messages)
+        for index in range(len(turn_messages) - 1, -1, -1):
+            raw_message = turn_messages[index]
             if not isinstance(raw_message, ToolMessage):
                 continue
             if raw_message.name != "search_titles":
                 continue
+            args = cls.latest_search_args(
+                turn_messages[:index],
+                getattr(raw_message, "tool_call_id", None),
+            )
             payload = cls.parse_tool_payload(raw_message)
             if not isinstance(payload, list):
-                continue
+                return SearchSnapshot(
+                    searched=True,
+                    candidates=[],
+                    error="The catalog search returned an unreadable payload.",
+                    args=args,
+                )
             if (
                 payload
                 and isinstance(payload[0], dict)
                 and payload[0].get("error")
             ):
-                last_error = str(payload[0]["error"])
-                continue
+                return SearchSnapshot(
+                    searched=True,
+                    candidates=[],
+                    error=str(payload[0]["error"]),
+                    args=args,
+                )
             candidates = [
                 item
                 for item in payload
                 if isinstance(item, dict) and item.get("id")
             ]
-            if candidates:
-                return SearchSnapshot(
-                    candidates=candidates,
-                    error=None,
-                    args=cls.latest_search_args(
-                        messages[:index],
-                        getattr(raw_message, "tool_call_id", None),
-                    ),
-                )
+            return SearchSnapshot(
+                searched=True, candidates=candidates, error=None, args=args
+            )
 
-        return SearchSnapshot(candidates=[], error=last_error, args=None)
+        return SearchSnapshot(
+            searched=False, candidates=[], error=None, args=None
+        )
+
+    @staticmethod
+    def latest_turn_messages(messages: list[Any]) -> list[Any]:
+        """Return the messages generated after the latest human turn began."""
+        for index in range(len(messages) - 1, -1, -1):
+            if isinstance(messages[index], HumanMessage):
+                return messages[index + 1 :]
+        return messages
 
     @classmethod
     def latest_search_args(
@@ -209,6 +238,14 @@ class CuratorResponseBuilder:
         notes: list[str] = []
         filtered = candidates
 
+        exclude_ids = cls.exclude_ids(search_args)
+        if exclude_ids:
+            filtered = [
+                candidate
+                for candidate in filtered
+                if str(candidate.get("id")) not in exclude_ids
+            ]
+
         min_year = cls.to_int((search_args or {}).get("min_year"))
         max_year = cls.to_int((search_args or {}).get("max_year"))
         if min_year is not None or max_year is not None:
@@ -228,6 +265,40 @@ class CuratorResponseBuilder:
                 return [], notes
 
         return filtered, notes
+
+    @classmethod
+    def active_context_from_args(
+        cls, search_args: dict[str, Any] | None
+    ) -> CuratorActiveContext:
+        """Build the inspectable active discovery context from tool args."""
+        args = search_args or {}
+        raw_genres = args.get("genres") or []
+        if isinstance(raw_genres, str):
+            raw_genres = [raw_genres]
+        genres = [str(genre) for genre in cast(list[Any], raw_genres)]
+        return CuratorActiveContext(
+            freeText=cls.to_str(args.get("free_text")),
+            genres=genres,
+            titleType=cls.to_str(args.get("title_type")),
+            minYear=cls.to_int(args.get("min_year")),
+            maxYear=cls.to_int(args.get("max_year")),
+            isAdult=cls.to_bool(args.get("is_adult"), default=False),
+            excludedTitleIds=cls.exclude_ids(args),
+        )
+
+    @staticmethod
+    def exclude_ids(search_args: dict[str, Any] | None) -> list[str]:
+        """Normalize excluded title IDs from tool args."""
+        if not search_args:
+            return []
+        raw_ids = search_args.get("exclude_ids") or []
+        if isinstance(raw_ids, str):
+            raw_ids = [raw_ids]
+        if not isinstance(raw_ids, list):
+            return []
+        return [
+            str(title_id) for title_id in raw_ids if title_id not in (None, "")
+        ]
 
     @staticmethod
     def year_range_note(min_year: int | None, max_year: int | None) -> str:
@@ -319,3 +390,18 @@ class CuratorResponseBuilder:
         if value in (None, ""):
             return None
         return str(value)
+
+    @staticmethod
+    def to_bool(value: Any, *, default: bool) -> bool:
+        """Coerce optional metadata into booleans."""
+        if value in (None, ""):
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes"}:
+                return True
+            if normalized in {"false", "0", "no"}:
+                return False
+        return bool(value)

--- a/services/langgraph/agent_service/src/agent_service/models.py
+++ b/services/langgraph/agent_service/src/agent_service/models.py
@@ -21,6 +21,33 @@ class CuratorTitle(BaseModel):
     )
 
 
+class CuratorActiveContext(BaseModel):
+    """Inspectable effective search arguments used for the latest turn."""
+
+    freeText: str | None = Field(
+        default=None, description="Effective free-text title search."
+    )
+    genres: list[str] = Field(
+        default_factory=list, description="Effective genre constraints."
+    )
+    titleType: str | None = Field(
+        default=None, description="Effective title format constraint."
+    )
+    minYear: int | None = Field(
+        default=None, description="Effective lower year bound."
+    )
+    maxYear: int | None = Field(
+        default=None, description="Effective upper year bound."
+    )
+    isAdult: bool = Field(
+        default=False, description="Whether adult titles are allowed."
+    )
+    excludedTitleIds: list[str] = Field(
+        default_factory=list,
+        description="Explicitly excluded prior title IDs for this thread.",
+    )
+
+
 class CuratorResponse(BaseModel):
     """Structured Kino Discover response."""
 
@@ -33,4 +60,8 @@ class CuratorResponse(BaseModel):
         default_factory=list,
         description="Short operational notes, such as search relaxations or missing data.",
         max_length=3,
+    )
+    activeContext: CuratorActiveContext = Field(
+        default_factory=CuratorActiveContext,
+        description="Effective search arguments used for this response turn.",
     )

--- a/services/langgraph/agent_service/src/agent_service/tools.py
+++ b/services/langgraph/agent_service/src/agent_service/tools.py
@@ -17,6 +17,7 @@ async def search_titles(
     title_type: str | None = None,
     min_year: int | None = None,
     max_year: int | None = None,
+    exclude_ids: list[str] | None = None,
     is_adult: bool = False,
     size: int = 8,
 ) -> list[dict[str, Any]]:
@@ -28,8 +29,10 @@ async def search_titles(
     popularity, trend data, or external web results. If the request mentions
     constraints this tool does not support directly, such as runtime,
     search by the closest supported fields first and filter/rank from the
-    returned records. Call this tool once per user request, then answer from the
-    grounded results without retrying or reformulating the search.
+    returned records. In follow-up turns, reuse supported constraints from the
+    current thread unless the user explicitly changes them. Call this tool once
+    per user request, then answer from the grounded results without retrying or
+    reformulating the search.
 
     Args:
         free_text: Keyword or title text for Kino's text search. Use short phrases
@@ -47,6 +50,11 @@ async def search_titles(
         max_year: Maximum release/start year, such as 2000 for requests like
             "through 2000" or "between 1990 and 2000". Leave empty if the
             user did not give an explicit upper year bound.
+        exclude_ids: Earlier Kino title IDs to suppress from the final grounded
+            candidates. Use this only when the user explicitly rejects already
+            shown titles in the same thread, such as "not those" or "different
+            ones". When using exclusions for a refinement turn, prefer `size=12`
+            to reduce empty repeat results.
         is_adult: Whether adult titles are allowed. Keep false unless the user
             explicitly asks to include adult content.
         size: Number of candidates to return. Use 5 to 12; default is 8.
@@ -64,6 +72,7 @@ async def search_titles(
         title_type=title_type,
         min_year=min_year,
         max_year=max_year,
+        exclude_ids=exclude_ids,
         is_adult=is_adult,
         size=size,
     )

--- a/services/langgraph/agent_service/src/agent_service/tools.py
+++ b/services/langgraph/agent_service/src/agent_service/tools.py
@@ -7,7 +7,10 @@ from typing import Any
 from langchain_core.tools import tool
 
 from agent_service.config import CuratorSettings
-from agent_service.data_service import KinoDataServiceClient
+from agent_service.data_service import (
+    KinoDataServiceClient,
+    TitleSearchRequest,
+)
 
 
 @tool(parse_docstring=True)
@@ -66,7 +69,7 @@ async def search_titles(
         auth_client_id=settings.auth_client_id,
         auth_client_secret=settings.auth_client_secret,
     )
-    return await client.search_titles(
+    search = TitleSearchRequest(
         free_text=free_text,
         genres=genres,
         title_type=title_type,
@@ -76,3 +79,4 @@ async def search_titles(
         is_adult=is_adult,
         size=size,
     )
+    return await client.search_titles(search)

--- a/services/langgraph/agent_service/tests/unit_tests/test_data_service.py
+++ b/services/langgraph/agent_service/tests/unit_tests/test_data_service.py
@@ -1,4 +1,10 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
 from agent_service.data_service import KinoDataServiceClient
+
+pytestmark = pytest.mark.anyio
 
 
 def test_search_params_include_year_bounds() -> None:
@@ -9,6 +15,7 @@ def test_search_params_include_year_bounds() -> None:
         min_year=1990,
         max_year=2000,
         is_adult=False,
+        page=0,
         size=8,
     )
 
@@ -21,3 +28,73 @@ def test_search_params_include_year_bounds() -> None:
         "minYear": 1990,
         "maxYear": 2000,
     }
+
+
+def test_search_params_include_page_number() -> None:
+    params = KinoDataServiceClient._search_params(
+        free_text="fargo",
+        genres=None,
+        title_type=None,
+        min_year=None,
+        max_year=None,
+        is_adult=False,
+        page=2,
+        size=12,
+    )
+
+    assert params["page"] == 2
+
+
+async def test_search_titles_fetches_additional_pages_for_exclusions() -> None:
+    client = KinoDataServiceClient(
+        base_url="http://data-service/api/v1/data",
+        auth_service_url="http://auth/api/v1/auth",
+        auth_client_id="agent-service",
+        auth_client_secret="secret",
+    )
+
+    page_results = iter(
+        [
+            (
+                [
+                    {"id": "a1", "title": "Heat"},
+                    {"id": "a2", "title": "Se7en"},
+                ],
+                False,
+            ),
+            (
+                [
+                    {"id": "a2", "title": "Se7en"},
+                    {"id": "a3", "title": "Ronin"},
+                    {"id": "a4", "title": "Run Lola Run"},
+                ],
+                True,
+            ),
+        ]
+    )
+
+    async def fake_fetch_titles_page(
+        *args: object, **kwargs: object
+    ) -> tuple[list[dict[str, str]], bool]:
+        return next(page_results)
+
+    object.__setattr__(
+        client, "_authorization_header", AsyncMock(return_value={})
+    )
+    object.__setattr__(client, "_fetch_titles_page", fake_fetch_titles_page)
+
+    result = await client.search_titles(
+        free_text=None,
+        genres=["Action"],
+        title_type="movie",
+        min_year=None,
+        max_year=None,
+        exclude_ids=["a1", "a2"],
+        is_adult=False,
+        size=3,
+    )
+
+    assert result == [
+        {"id": "a3", "title": "Ronin"},
+        {"id": "a4", "title": "Run Lola Run"},
+    ]

--- a/services/langgraph/agent_service/tests/unit_tests/test_data_service.py
+++ b/services/langgraph/agent_service/tests/unit_tests/test_data_service.py
@@ -2,19 +2,27 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from agent_service.data_service import KinoDataServiceClient
+from agent_service.data_service import (
+    KinoDataServiceClient,
+    TitleSearchRequest,
+)
 
 pytestmark = pytest.mark.anyio
 
 
 def test_search_params_include_year_bounds() -> None:
-    params = KinoDataServiceClient._search_params(
+    search = TitleSearchRequest(
         free_text=None,
         genres=["Action"],
         title_type="movie",
         min_year=1990,
         max_year=2000,
+        exclude_ids=None,
         is_adult=False,
+        size=8,
+    )
+    params = KinoDataServiceClient._search_params(
+        search=search,
         page=0,
         size=8,
     )
@@ -31,13 +39,18 @@ def test_search_params_include_year_bounds() -> None:
 
 
 def test_search_params_include_page_number() -> None:
-    params = KinoDataServiceClient._search_params(
+    search = TitleSearchRequest(
         free_text="fargo",
         genres=None,
         title_type=None,
         min_year=None,
         max_year=None,
+        exclude_ids=None,
         is_adult=False,
+        size=12,
+    )
+    params = KinoDataServiceClient._search_params(
+        search=search,
         page=2,
         size=12,
     )
@@ -82,8 +95,7 @@ async def test_search_titles_fetches_additional_pages_for_exclusions() -> None:
         client, "_authorization_header", AsyncMock(return_value={})
     )
     object.__setattr__(client, "_fetch_titles_page", fake_fetch_titles_page)
-
-    result = await client.search_titles(
+    search = TitleSearchRequest(
         free_text=None,
         genres=["Action"],
         title_type="movie",
@@ -93,6 +105,8 @@ async def test_search_titles_fetches_additional_pages_for_exclusions() -> None:
         is_adult=False,
         size=3,
     )
+
+    result = await client.search_titles(search)
 
     assert result == [
         {"id": "a3", "title": "Ronin"},

--- a/services/langgraph/agent_service/tests/unit_tests/test_data_service.py
+++ b/services/langgraph/agent_service/tests/unit_tests/test_data_service.py
@@ -22,9 +22,7 @@ def test_search_params_include_year_bounds() -> None:
         size=8,
     )
     params = KinoDataServiceClient._search_params(
-        search=search,
-        page=0,
-        size=8,
+        search=search, page=0, size=8
     )
 
     assert params == {
@@ -50,9 +48,7 @@ def test_search_params_include_page_number() -> None:
         size=12,
     )
     params = KinoDataServiceClient._search_params(
-        search=search,
-        page=2,
-        size=12,
+        search=search, page=2, size=12
     )
 
     assert params["page"] == 2

--- a/services/langgraph/agent_service/tests/unit_tests/test_graph_postprocessing.py
+++ b/services/langgraph/agent_service/tests/unit_tests/test_graph_postprocessing.py
@@ -93,6 +93,15 @@ def test_finalize_agent_state_builds_grounded_titles() -> None:
 
     assert [title.id for title in response.titles] == ["a1", "a2", "a3"]
     assert response.notes == []
+    assert response.activeContext.model_dump() == {
+        "freeText": None,
+        "genres": ["Thriller"],
+        "titleType": "movie",
+        "minYear": 1990,
+        "maxYear": None,
+        "isAdult": False,
+        "excludedTitleIds": [],
+    }
 
 
 def test_finalize_agent_state_uses_grounded_candidate_fields() -> None:
@@ -128,6 +137,15 @@ def test_finalize_agent_state_uses_grounded_candidate_fields() -> None:
     assert response.titles[0].year == 1995
     assert response.titles[0].titleType == "movie"
     assert response.titles[0].genres == ["Crime", "Thriller"]
+    assert response.activeContext.model_dump() == {
+        "freeText": None,
+        "genres": [],
+        "titleType": None,
+        "minYear": None,
+        "maxYear": None,
+        "isAdult": False,
+        "excludedTitleIds": [],
+    }
 
 
 def test_finalize_agent_state_reports_missing_year_matches() -> None:
@@ -272,6 +290,15 @@ def test_finalize_agent_state_reads_year_bounds_from_tool_args() -> None:
     response = builder.finalize_agent_state(state)
 
     assert [title.id for title in response.titles] == ["a1"]
+    assert response.activeContext.model_dump() == {
+        "freeText": None,
+        "genres": ["Action"],
+        "titleType": None,
+        "minYear": 1990,
+        "maxYear": 2000,
+        "isAdult": False,
+        "excludedTitleIds": [],
+    }
 
 
 def test_finalize_agent_state_does_not_parse_year_bounds_from_prompt() -> None:
@@ -309,6 +336,383 @@ def test_finalize_agent_state_does_not_parse_year_bounds_from_prompt() -> None:
     assert response.notes == [
         "The catalog search returned fewer than three grounded matches."
     ]
+    assert response.activeContext.model_dump() == {
+        "freeText": None,
+        "genres": [],
+        "titleType": None,
+        "minYear": None,
+        "maxYear": None,
+        "isAdult": False,
+        "excludedTitleIds": [],
+    }
+
+
+def test_finalize_agent_state_follow_up_refinement_uses_latest_effective_args() -> (
+    None
+):
+    state = {
+        "messages": [
+            HumanMessage(content="Discover thrillers from 1990 onward."),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "search_titles",
+                        "args": {
+                            "genres": ["Thriller"],
+                            "min_year": 1990,
+                            "size": 8,
+                        },
+                        "id": "call-1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(
+                content=json.dumps(
+                    [
+                        {
+                            "id": "a1",
+                            "title": "Heat",
+                            "year": 1995,
+                            "titleType": "movie",
+                            "genres": ["Crime", "Thriller"],
+                        }
+                    ]
+                ),
+                tool_call_id="call-1",
+                name="search_titles",
+            ),
+            HumanMessage(content="Movie only."),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "search_titles",
+                        "args": {
+                            "genres": ["Thriller"],
+                            "min_year": 1990,
+                            "title_type": "movie",
+                            "size": 8,
+                        },
+                        "id": "call-2",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(
+                content=json.dumps(
+                    [
+                        {
+                            "id": "a2",
+                            "title": "Se7en",
+                            "year": 1995,
+                            "titleType": "movie",
+                            "genres": ["Crime", "Mystery", "Thriller"],
+                        }
+                    ]
+                ),
+                tool_call_id="call-2",
+                name="search_titles",
+            ),
+        ]
+    }
+
+    response = builder.finalize_agent_state(state)
+
+    assert [title.id for title in response.titles] == ["a2"]
+    assert response.activeContext.model_dump() == {
+        "freeText": None,
+        "genres": ["Thriller"],
+        "titleType": "movie",
+        "minYear": 1990,
+        "maxYear": None,
+        "isAdult": False,
+        "excludedTitleIds": [],
+    }
+
+
+def test_finalize_agent_state_latest_empty_search_is_authoritative() -> None:
+    state = {
+        "messages": [
+            HumanMessage(content="Discover thrillers."),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "search_titles",
+                        "args": {"genres": ["Thriller"], "size": 8},
+                        "id": "call-1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(
+                content=json.dumps(
+                    [
+                        {
+                            "id": "a1",
+                            "title": "Heat",
+                            "year": 1995,
+                            "titleType": "movie",
+                            "genres": ["Crime", "Thriller"],
+                        }
+                    ]
+                ),
+                tool_call_id="call-1",
+                name="search_titles",
+            ),
+            HumanMessage(content="Only documentaries."),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "search_titles",
+                        "args": {"genres": ["Documentary"], "size": 8},
+                        "id": "call-2",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(
+                content=json.dumps([]),
+                tool_call_id="call-2",
+                name="search_titles",
+            ),
+        ]
+    }
+
+    response = builder.finalize_agent_state(state)
+
+    assert response.titles == []
+    assert response.notes == [
+        "The catalog search did not return any grounded candidates."
+    ]
+    assert response.activeContext.model_dump() == {
+        "freeText": None,
+        "genres": ["Documentary"],
+        "titleType": None,
+        "minYear": None,
+        "maxYear": None,
+        "isAdult": False,
+        "excludedTitleIds": [],
+    }
+
+
+def test_finalize_agent_state_latest_error_search_is_authoritative() -> None:
+    state = {
+        "messages": [
+            HumanMessage(content="Discover thrillers."),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "search_titles",
+                        "args": {"genres": ["Thriller"], "size": 8},
+                        "id": "call-1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(
+                content=json.dumps(
+                    [
+                        {
+                            "id": "a1",
+                            "title": "Heat",
+                            "year": 1995,
+                            "titleType": "movie",
+                            "genres": ["Crime", "Thriller"],
+                        }
+                    ]
+                ),
+                tool_call_id="call-1",
+                name="search_titles",
+            ),
+            HumanMessage(content="Only documentaries."),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "search_titles",
+                        "args": {"genres": ["Documentary"], "size": 8},
+                        "id": "call-2",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(
+                content=json.dumps(
+                    [{"error": "Failed to query Kino data service: boom"}]
+                ),
+                tool_call_id="call-2",
+                name="search_titles",
+            ),
+        ]
+    }
+
+    response = builder.finalize_agent_state(state)
+
+    assert response.titles == []
+    assert response.notes == ["Failed to query Kino data service: boom"]
+    assert response.activeContext.model_dump() == {
+        "freeText": None,
+        "genres": ["Documentary"],
+        "titleType": None,
+        "minYear": None,
+        "maxYear": None,
+        "isAdult": False,
+        "excludedTitleIds": [],
+    }
+
+
+def test_finalize_agent_state_excludes_titles_only_when_tool_args_request_it() -> (
+    None
+):
+    state = {
+        "messages": [
+            HumanMessage(content="Discover action movies."),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "search_titles",
+                        "args": {"genres": ["Action"], "size": 8},
+                        "id": "call-1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(
+                content=json.dumps(
+                    [
+                        {
+                            "id": "a1",
+                            "title": "Heat",
+                            "year": 1995,
+                            "titleType": "movie",
+                            "genres": ["Action", "Crime"],
+                        },
+                        {
+                            "id": "a2",
+                            "title": "Se7en",
+                            "year": 1995,
+                            "titleType": "movie",
+                            "genres": ["Action", "Mystery"],
+                        },
+                    ]
+                ),
+                tool_call_id="call-1",
+                name="search_titles",
+            ),
+            HumanMessage(content="Not those. Different ones."),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "search_titles",
+                        "args": {
+                            "genres": ["Action"],
+                            "exclude_ids": ["a1", "a2"],
+                            "size": 12,
+                        },
+                        "id": "call-2",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(
+                content=json.dumps(
+                    [
+                        {
+                            "id": "a1",
+                            "title": "Heat",
+                            "year": 1995,
+                            "titleType": "movie",
+                            "genres": ["Action", "Crime"],
+                        },
+                        {
+                            "id": "a2",
+                            "title": "Se7en",
+                            "year": 1995,
+                            "titleType": "movie",
+                            "genres": ["Action", "Mystery"],
+                        },
+                        {
+                            "id": "a3",
+                            "title": "Ronin",
+                            "year": 1998,
+                            "titleType": "movie",
+                            "genres": ["Action", "Crime", "Thriller"],
+                        },
+                        {
+                            "id": "a4",
+                            "title": "Run Lola Run",
+                            "year": 1998,
+                            "titleType": "movie",
+                            "genres": ["Action", "Crime", "Thriller"],
+                        },
+                    ]
+                ),
+                tool_call_id="call-2",
+                name="search_titles",
+            ),
+        ]
+    }
+
+    response = builder.finalize_agent_state(state)
+
+    assert [title.id for title in response.titles] == ["a3", "a4"]
+    assert response.notes == [
+        "The catalog search returned fewer than three grounded matches."
+    ]
+    assert response.activeContext.model_dump() == {
+        "freeText": None,
+        "genres": ["Action"],
+        "titleType": None,
+        "minYear": None,
+        "maxYear": None,
+        "isAdult": False,
+        "excludedTitleIds": ["a1", "a2"],
+    }
+
+
+def test_finalize_agent_state_no_tool_turn_returns_empty_response() -> None:
+    state = {
+        "messages": [
+            HumanMessage(content="Discover thrillers."),
+            AIMessage(
+                content="I can help discover titles from Kino's catalog."
+            ),
+        ]
+    }
+
+    response = builder.finalize_agent_state(state)
+
+    assert response == CuratorResponse()
+
+
+def test_active_context_normalizes_json_string_tool_args() -> None:
+    args = builder.normalize_tool_args(
+        json.dumps(
+            {
+                "genres": ["Action"],
+                "min_year": 1990,
+                "exclude_ids": ["a1"],
+                "is_adult": False,
+            }
+        )
+    )
+
+    assert builder.active_context_from_args(args).model_dump() == {
+        "freeText": None,
+        "genres": ["Action"],
+        "titleType": None,
+        "minYear": 1990,
+        "maxYear": None,
+        "isAdult": False,
+        "excludedTitleIds": ["a1"],
+    }
 
 
 def test_sync_middleware_short_circuits_after_search() -> None:
@@ -401,5 +805,46 @@ def test_after_agent_returns_deterministic_titles_only() -> None:
             "notes": [
                 "The catalog search returned fewer than three grounded matches."
             ],
+            "activeContext": {
+                "freeText": None,
+                "genres": ["Action"],
+                "titleType": None,
+                "minYear": 1990,
+                "maxYear": None,
+                "isAdult": False,
+                "excludedTitleIds": [],
+            },
+        }
+    }
+
+
+def test_after_agent_no_tool_turn_returns_empty_structured_response() -> None:
+    response_middleware = middleware()
+
+    result = response_middleware.after_agent(
+        {
+            "messages": [
+                HumanMessage(content="How do you work?"),
+                AIMessage(
+                    content="I discover grounded titles from Kino's catalog."
+                ),
+            ]
+        },
+        runtime=None,
+    )
+
+    assert result == {
+        "structured_response": {
+            "titles": [],
+            "notes": [],
+            "activeContext": {
+                "freeText": None,
+                "genres": [],
+                "titleType": None,
+                "minYear": None,
+                "maxYear": None,
+                "isAdult": False,
+                "excludedTitleIds": [],
+            },
         }
     }


### PR DESCRIPTION
## Summary
- make the latest search turn authoritative even on empty/error results
- avoid fake structured no-candidate responses on no-tool informational turns
- make exclude_ids drive fresh candidate selection via iterative paging
- narrow activeContext to the effective args used for the latest turn

## Testing
- ~/.local/bin/uv run --group dev pytest tests/unit_tests/test_graph_postprocessing.py tests/unit_tests/test_data_service.py tests/unit_tests/test_config.py tests/unit_tests/test_configuration.py
- ~/.local/bin/uv run --group dev python -m ruff check src tests
- git diff --check