### PR TITLE
Add guarded manual dispatch to publish workflows

### DIFF
--- a/.github/scripts/write_image_release_manifest.py
+++ b/.github/scripts/write_image_release_manifest.py
@@ -1,0 +1,67 @@
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+def append_github_output(name: str, value: str) -> None:
+    github_output = os.getenv("GITHUB_OUTPUT")
+    if not github_output:
+        return
+
+    with open(github_output, "a", encoding="utf-8") as handle:
+        handle.write(f"{name}={value}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Write a small image release manifest for GitHub Actions handoff."
+    )
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--terraform-var")
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--digest", required=True)
+    parser.add_argument("--git-revision", required=True)
+    parser.add_argument("--git-ref", required=True)
+    parser.add_argument("--git-commit-subject", required=True)
+    parser.add_argument("--workflow", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    image_tag = f"{args.repository}:{args.tag}"
+    image_ref = f"{args.repository}@{args.digest}"
+    short_git_revision = args.git_revision[:7]
+    terraform_export = (
+        f"{args.terraform_var}={image_ref}" if args.terraform_var else ""
+    )
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "service": args.service,
+        "gitRevision": args.git_revision,
+        "gitShortRevision": short_git_revision,
+        "gitRef": args.git_ref,
+        "gitCommitSubject": args.git_commit_subject,
+        "workflow": args.workflow,
+        "imageTag": image_tag,
+        "imageDigest": args.digest,
+        "imageRef": image_ref,
+    }
+    if args.terraform_var:
+        manifest["terraformVariable"] = args.terraform_var
+        manifest["terraformExport"] = terraform_export
+
+    output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    append_github_output("image_ref", image_ref)
+    append_github_output("terraform_export", terraform_export)
+    append_github_output("has_terraform_export", "true" if terraform_export else "false")
+    append_github_output("manifest_path", str(output_path))
+    append_github_output("git_commit_subject", args.git_commit_subject)
+    append_github_output("short_git_revision", short_git_revision)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/dev-kino-auth-service.yaml
+++ b/.github/workflows/dev-kino-auth-service.yaml
@@ -8,18 +8,67 @@ on:
       - develop
     paths:
       - services/spring-boot/auth_service/**
+      - .github/workflows/dev-kino-auth-service.yaml
+  # Allows an operator to run the workflow manually from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      publish_image:
+        description: Publish the dev image from the selected ref. Publishing still requires refs/heads/develop.
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: kino-auth_service
+  PUBLISH_REF: refs/heads/develop
+  PUBLISH_TAG: dev
 
 # Creates a job ID (build) and declares the type of machine that the job should run on.
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
+      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
         uses: actions/checkout@v5
+
+      # Decide once whether this run is allowed to publish or should stay in validation mode.
+      - name: Decide publish mode
+        id: publish_decision
+        run: |
+          should_publish=false
+          non_publish_reason="This run will validate only."
+          publish_requested="$(python3 -c 'import json, sys; event = json.load(open(sys.argv[1])); print(str(event.get("inputs", {}).get("publish_image", "false")).lower())' "$GITHUB_EVENT_PATH")"
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" == "true" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" != "true" ]]; then
+            non_publish_reason="publish_image=false"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "${{ env.PUBLISH_REF }}" ]]; then
+            non_publish_reason="selected ref does not match ${{ env.PUBLISH_REF }}"
+          fi
+
+          {
+            echo "should_publish=$should_publish"
+            echo "non_publish_reason<<EOF"
+            echo "$non_publish_reason"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
-      # Signs in to Docker Hub, using the "Docker Login" action and your Docker Hub credentials.
+      # Docker Hub credentials are only needed when this run is actually allowed to publish the dev image.
       - name: Login to Docker Hub
+        if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -28,9 +77,37 @@ jobs:
       # Creates a BuildKit builder instance using the "Docker Setup Buildx" action.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      # Manual runs that stay in validation mode still build the image locally for CI parity.
+      - name: Build image for CI validation
+        if: steps.publish_decision.outputs.should_publish != 'true'
+        uses: docker/build-push-action@v7
+        with:
+          # The build context (https://docs.docker.com/build/building/context/), default is "."
+          context: services/spring-boot/
+          # Filepath to the Dockerfile, default is "./Dockerfile"
+          file: services/spring-boot/auth_service/Dockerfile
+          # CI-only validation builds stay local to the runner.
+          push: false
+          # Local tag used only inside the CI runner.
+          tags: ${{ env.IMAGE_NAME }}:dev-ci
+
+      # Manual runs that stay in validation mode still explain why no publish happened.
+      - name: Publish validation summary
+        if: github.event_name == 'workflow_dispatch' && steps.publish_decision.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Validation-only run"
+            echo
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Publish requested: \`${{ inputs.publish_image }}\`"
+            echo "- Reason: ${{ steps.publish_decision.outputs.non_publish_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
         
-      # Builds the container image and pushes it to the Docker Hub repository, using "Build and push Docker images".
+      # Canonical branch pushes and explicit manual publishes on that branch are allowed to refresh the dev tag.
       - name: Build and push
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: publish_image
         uses: docker/build-push-action@v7
         with:
           # The build context (https://docs.docker.com/build/building/context/), default is "."
@@ -40,4 +117,46 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/kino-auth_service:dev
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.PUBLISH_TAG }}
+
+      # Build a small release manifest so operators and later jobs can consume the exact deploy input.
+      - name: Write release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: release_manifest
+        run: |
+          python3 .github/scripts/write_image_release_manifest.py \
+            --service dev-auth-service \
+            --terraform-var TF_VAR_auth_service_image_ref \
+            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --tag "${{ env.PUBLISH_TAG }}" \
+            --digest "${{ steps.publish_image.outputs.digest }}" \
+            --git-revision "${{ github.sha }}" \
+            --git-ref "${{ github.ref }}" \
+            --git-commit-subject "$(git log -1 --pretty=%s)" \
+            --workflow "${{ github.workflow }}" \
+            --output release-manifest.json
+
+      # Surface the exact copy-paste line directly on the run summary page.
+      - name: Publish workflow summary
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        run: |
+          {
+            echo "## Published dev auth-service image"
+            echo
+            echo "- Commit: \`${{ steps.release_manifest.outputs.short_git_revision }}\` ${{ steps.release_manifest.outputs.git_commit_subject }}"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Image ref: \`${{ steps.release_manifest.outputs.image_ref }}\`"
+            echo "- Terraform export:"
+            echo
+            echo '```bash'
+            echo "${{ steps.release_manifest.outputs.terraform_export }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the release manifest so operators can retrieve it without opening the raw step logs.
+      - name: Upload release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-kino-auth-service-release-manifest
+          path: release-manifest.json

--- a/.github/workflows/dev-kino-ui.yaml
+++ b/.github/workflows/dev-kino-ui.yaml
@@ -8,21 +8,68 @@ on:
       - develop
     paths:
       - uis/react-ui/kino-ui/**
+      - .github/workflows/dev-kino-ui.yaml
   
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
+    inputs:
+      publish_image:
+        description: Publish the dev image from the selected ref. Publishing still requires refs/heads/develop.
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: kino-ui
+  PUBLISH_REF: refs/heads/develop
+  PUBLISH_TAG: dev
 
 # Creates a job ID (build) and declares the type of machine that the job should run on.
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
+      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
         uses: actions/checkout@v5
+
+      # Decide once whether this run is allowed to publish or should stay in validation mode.
+      - name: Decide publish mode
+        id: publish_decision
+        run: |
+          should_publish=false
+          non_publish_reason="This run will validate only."
+          publish_requested="$(python3 -c 'import json, sys; event = json.load(open(sys.argv[1])); print(str(event.get("inputs", {}).get("publish_image", "false")).lower())' "$GITHUB_EVENT_PATH")"
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" == "true" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" != "true" ]]; then
+            non_publish_reason="publish_image=false"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "${{ env.PUBLISH_REF }}" ]]; then
+            non_publish_reason="selected ref does not match ${{ env.PUBLISH_REF }}"
+          fi
+
+          {
+            echo "should_publish=$should_publish"
+            echo "non_publish_reason<<EOF"
+            echo "$non_publish_reason"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
-      # Signs in to Docker Hub, using the "Docker Login" action and your Docker Hub credentials.
+      # Docker Hub credentials are only needed when this run is actually allowed to publish the dev image.
       - name: Login to Docker Hub
+        if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -32,8 +79,36 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         
-      # Builds the container image and pushes it to the Docker Hub repository, using "Build and push Docker images".
+      # Manual runs that stay in validation mode still build the image locally for CI parity.
+      - name: Build image for CI validation
+        if: steps.publish_decision.outputs.should_publish != 'true'
+        uses: docker/build-push-action@v7
+        with:
+          # The build context (https://docs.docker.com/build/building/context/), default is "."
+          context: uis/react-ui/kino-ui/
+          # Filepath to the Dockerfile, default is "./Dockerfile"
+          file: uis/react-ui/kino-ui/Dockerfile-dev
+          # CI-only validation builds stay local to the runner.
+          push: false
+          # Local tag used only inside the CI runner.
+          tags: ${{ env.IMAGE_NAME }}:dev-ci
+
+      # Manual runs that stay in validation mode still explain why no publish happened.
+      - name: Publish validation summary
+        if: github.event_name == 'workflow_dispatch' && steps.publish_decision.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Validation-only run"
+            echo
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Publish requested: \`${{ inputs.publish_image }}\`"
+            echo "- Reason: ${{ steps.publish_decision.outputs.non_publish_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Canonical branch pushes and explicit manual publishes on that branch are allowed to refresh the dev tag.
       - name: Build and push
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: publish_image
         uses: docker/build-push-action@v7
         with:
           # The build context (https://docs.docker.com/build/building/context/), default is "."
@@ -43,4 +118,46 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/kino-ui:dev
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.PUBLISH_TAG }}
+
+      # Build a small release manifest so operators and later jobs can consume the exact deploy input.
+      - name: Write release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: release_manifest
+        run: |
+          python3 .github/scripts/write_image_release_manifest.py \
+            --service dev-ui \
+            --terraform-var TF_VAR_ui_image_ref \
+            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --tag "${{ env.PUBLISH_TAG }}" \
+            --digest "${{ steps.publish_image.outputs.digest }}" \
+            --git-revision "${{ github.sha }}" \
+            --git-ref "${{ github.ref }}" \
+            --git-commit-subject "$(git log -1 --pretty=%s)" \
+            --workflow "${{ github.workflow }}" \
+            --output release-manifest.json
+
+      # Surface the exact copy-paste line directly on the run summary page.
+      - name: Publish workflow summary
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        run: |
+          {
+            echo "## Published dev UI image"
+            echo
+            echo "- Commit: \`${{ steps.release_manifest.outputs.short_git_revision }}\` ${{ steps.release_manifest.outputs.git_commit_subject }}"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Image ref: \`${{ steps.release_manifest.outputs.image_ref }}\`"
+            echo "- Terraform export:"
+            echo
+            echo '```bash'
+            echo "${{ steps.release_manifest.outputs.terraform_export }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the release manifest so operators can retrieve it without opening the raw step logs.
+      - name: Upload release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-kino-ui-release-manifest
+          path: release-manifest.json

--- a/.github/workflows/kino-agent-service.yaml
+++ b/.github/workflows/kino-agent-service.yaml
@@ -15,6 +15,22 @@ on:
     paths:
       - services/langgraph/agent_service/**
       - .github/workflows/kino-agent-service.yaml
+  # Allows an operator to run the workflow manually from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      publish_image:
+        description: Publish the image from the selected ref. Publishing still requires refs/heads/master.
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: kino-agent_service
+  PUBLISH_REF: refs/heads/master
 
 jobs:
   test:
@@ -66,23 +82,123 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
+    outputs:
+      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
+      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # Decide once whether this run is allowed to publish or should stay in validation mode.
+      - name: Decide publish mode
+        id: publish_decision
+        run: |
+          should_publish=false
+          non_publish_reason="This run will validate only."
+          publish_requested="$(python3 -c 'import json, sys; event = json.load(open(sys.argv[1])); print(str(event.get("inputs", {}).get("publish_image", "false")).lower())' "$GITHUB_EVENT_PATH")"
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" == "true" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" != "true" ]]; then
+            non_publish_reason="publish_image=false"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "${{ env.PUBLISH_REF }}" ]]; then
+            non_publish_reason="selected ref does not match ${{ env.PUBLISH_REF }}"
+          fi
+
+          {
+            echo "should_publish=$should_publish"
+            echo "non_publish_reason<<EOF"
+            echo "$non_publish_reason"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Docker Hub credentials are only needed when this run is actually allowed to publish the image.
       - name: Login to Docker Hub
+        if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Buildx is used consistently for both CI-only image builds and published images.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # Pull requests and non-publishing manual runs only validate that the Dockerfile still builds.
+      - name: Build image for CI validation
+        if: steps.publish_decision.outputs.should_publish != 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: services/langgraph/agent_service
+          file: services/langgraph/agent_service/Dockerfile
+          push: false
+          tags: ${{ env.IMAGE_NAME }}:ci
+
+      # Manual runs that stay in validation mode still explain why no publish happened.
+      - name: Publish validation summary
+        if: github.event_name == 'workflow_dispatch' && steps.publish_decision.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Validation-only run"
+            echo
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Publish requested: \`${{ inputs.publish_image }}\`"
+            echo "- Reason: ${{ steps.publish_decision.outputs.non_publish_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Canonical branch pushes and explicit manual publishes on that branch are allowed to refresh the registry tag.
       - name: Build and push
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: publish_image
         uses: docker/build-push-action@v7
         with:
           context: services/langgraph/agent_service
           file: services/langgraph/agent_service/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/kino-agent_service:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+
+      # Build a small release manifest so operators and later jobs can consume the exact deploy input.
+      - name: Write release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: release_manifest
+        run: |
+          python3 .github/scripts/write_image_release_manifest.py \
+            --service agent-service \
+            --terraform-var TF_VAR_agent_service_image_ref \
+            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --tag latest \
+            --digest "${{ steps.publish_image.outputs.digest }}" \
+            --git-revision "${{ github.sha }}" \
+            --git-ref "${{ github.ref }}" \
+            --git-commit-subject "$(git log -1 --pretty=%s)" \
+            --workflow "${{ github.workflow }}" \
+            --output release-manifest.json
+
+      # Surface the exact copy-paste line directly on the run summary page.
+      - name: Publish workflow summary
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        run: |
+          {
+            echo "## Published agent-service image"
+            echo
+            echo "- Commit: \`${{ steps.release_manifest.outputs.short_git_revision }}\` ${{ steps.release_manifest.outputs.git_commit_subject }}"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Image ref: \`${{ steps.release_manifest.outputs.image_ref }}\`"
+            echo "- Terraform export:"
+            echo
+            echo '```bash'
+            echo "${{ steps.release_manifest.outputs.terraform_export }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the release manifest so operators can retrieve it without opening the raw step logs.
+      - name: Upload release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kino-agent-service-release-manifest
+          path: release-manifest.json

--- a/.github/workflows/kino-auth-service.yaml
+++ b/.github/workflows/kino-auth-service.yaml
@@ -7,23 +7,72 @@ on:
       - master
     paths:
       - services/spring-boot/auth_service/**
+      - .github/workflows/kino-auth-service.yaml
   pull_request:
     branches:
       - master
     paths:
       - services/spring-boot/auth_service/**
+      - .github/workflows/kino-auth-service.yaml
+  # Allows an operator to run the workflow manually from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      publish_image:
+        description: Publish the image from the selected ref. Publishing still requires refs/heads/master.
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: kino-auth_service
+  PUBLISH_REF: refs/heads/master
 
 # Creates a job ID (build) and declares the type of machine that the job should run on.
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
+      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
         uses: actions/checkout@v5
+
+      # Decide once whether this run is allowed to publish or should stay in validation mode.
+      - name: Decide publish mode
+        id: publish_decision
+        run: |
+          should_publish=false
+          non_publish_reason="This run will validate only."
+          publish_requested="$(python3 -c 'import json, sys; event = json.load(open(sys.argv[1])); print(str(event.get("inputs", {}).get("publish_image", "false")).lower())' "$GITHUB_EVENT_PATH")"
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" == "true" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" != "true" ]]; then
+            non_publish_reason="publish_image=false"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "${{ env.PUBLISH_REF }}" ]]; then
+            non_publish_reason="selected ref does not match ${{ env.PUBLISH_REF }}"
+          fi
+
+          {
+            echo "should_publish=$should_publish"
+            echo "non_publish_reason<<EOF"
+            echo "$non_publish_reason"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
-      # Signs in to Docker Hub, using the "Docker Login" action and your Docker Hub credentials.
+      # Docker Hub credentials are only needed when this run is actually allowed to publish the image.
       - name: Login to Docker Hub
+        if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -33,8 +82,36 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         
-      # Builds the container image and pushes it to the Docker Hub repository, using "Build and push Docker images".
+      # Pull requests and non-publishing manual runs only validate that the Dockerfile still builds.
+      - name: Build image for CI validation
+        if: steps.publish_decision.outputs.should_publish != 'true'
+        uses: docker/build-push-action@v7
+        with:
+          # The build context (https://docs.docker.com/build/building/context/), default is "."
+          context: services/spring-boot/
+          # Filepath to the Dockerfile, default is "./Dockerfile"
+          file: services/spring-boot/auth_service/Dockerfile
+          # CI-only validation builds stay local to the runner.
+          push: false
+          # Local tag used only inside the CI runner.
+          tags: ${{ env.IMAGE_NAME }}:ci
+
+      # Manual runs that stay in validation mode still explain why no publish happened.
+      - name: Publish validation summary
+        if: github.event_name == 'workflow_dispatch' && steps.publish_decision.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Validation-only run"
+            echo
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Publish requested: \`${{ inputs.publish_image }}\`"
+            echo "- Reason: ${{ steps.publish_decision.outputs.non_publish_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Canonical branch pushes and explicit manual publishes on that branch are allowed to refresh the registry tag.
       - name: Build and push
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: publish_image
         uses: docker/build-push-action@v7
         with:
           # The build context (https://docs.docker.com/build/building/context/), default is "."
@@ -44,4 +121,46 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/kino-auth_service:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+
+      # Build a small release manifest so operators and later jobs can consume the exact deploy input.
+      - name: Write release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: release_manifest
+        run: |
+          python3 .github/scripts/write_image_release_manifest.py \
+            --service auth-service \
+            --terraform-var TF_VAR_auth_service_image_ref \
+            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --tag latest \
+            --digest "${{ steps.publish_image.outputs.digest }}" \
+            --git-revision "${{ github.sha }}" \
+            --git-ref "${{ github.ref }}" \
+            --git-commit-subject "$(git log -1 --pretty=%s)" \
+            --workflow "${{ github.workflow }}" \
+            --output release-manifest.json
+
+      # Surface the exact copy-paste line directly on the run summary page.
+      - name: Publish workflow summary
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        run: |
+          {
+            echo "## Published auth-service image"
+            echo
+            echo "- Commit: \`${{ steps.release_manifest.outputs.short_git_revision }}\` ${{ steps.release_manifest.outputs.git_commit_subject }}"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Image ref: \`${{ steps.release_manifest.outputs.image_ref }}\`"
+            echo "- Terraform export:"
+            echo
+            echo '```bash'
+            echo "${{ steps.release_manifest.outputs.terraform_export }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the release manifest so operators can retrieve it without opening the raw step logs.
+      - name: Upload release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kino-auth-service-release-manifest
+          path: release-manifest.json

--- a/.github/workflows/kino-data-service.yaml
+++ b/.github/workflows/kino-data-service.yaml
@@ -8,25 +8,73 @@ on:
       - master
     paths:
       - services/spring-boot/data_service/**
+      - .github/workflows/kino-data-service.yaml
   # Specifies that this workflow should run on every pull request event targeting the branches in the list.
   pull_request:
     branches:
       - master
     paths:
       - services/spring-boot/data_service/**
+      - .github/workflows/kino-data-service.yaml
+  # Allows an operator to run the workflow manually from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      publish_image:
+        description: Publish the image from the selected ref. Publishing still requires refs/heads/master.
+        required: true
+        default: false
+        type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: kino-data_service
+  PUBLISH_REF: refs/heads/master
 
 # Creates a job ID (build) and declares the type of machine that the job should run on.
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
+      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
         uses: actions/checkout@v5
+
+      # Decide once whether this run is allowed to publish or should stay in validation mode.
+      - name: Decide publish mode
+        id: publish_decision
+        run: |
+          should_publish=false
+          non_publish_reason="This run will validate only."
+          publish_requested="$(python3 -c 'import json, sys; event = json.load(open(sys.argv[1])); print(str(event.get("inputs", {}).get("publish_image", "false")).lower())' "$GITHUB_EVENT_PATH")"
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" == "true" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" != "true" ]]; then
+            non_publish_reason="publish_image=false"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "${{ env.PUBLISH_REF }}" ]]; then
+            non_publish_reason="selected ref does not match ${{ env.PUBLISH_REF }}"
+          fi
+
+          {
+            echo "should_publish=$should_publish"
+            echo "non_publish_reason<<EOF"
+            echo "$non_publish_reason"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
-      # Signs in to Docker Hub, using the "Docker Login" action and your Docker Hub credentials.
+      # Docker Hub credentials are only needed when this run is actually allowed to publish the image.
       - name: Login to Docker Hub
+        if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -36,8 +84,36 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         
-      # Builds the container image and pushes it to the Docker Hub repository, using "Build and push Docker images".
+      # Pull requests and non-publishing manual runs only validate that the Dockerfile still builds.
+      - name: Build image for CI validation
+        if: steps.publish_decision.outputs.should_publish != 'true'
+        uses: docker/build-push-action@v7
+        with:
+          # The build context (https://docs.docker.com/build/building/context/), default is "."
+          context: services/spring-boot/
+          # Filepath to the Dockerfile, default is "./Dockerfile"
+          file: services/spring-boot/data_service/Dockerfile
+          # CI-only validation builds stay local to the runner.
+          push: false
+          # Local tag used only inside the CI runner.
+          tags: ${{ env.IMAGE_NAME }}:ci
+
+      # Manual runs that stay in validation mode still explain why no publish happened.
+      - name: Publish validation summary
+        if: github.event_name == 'workflow_dispatch' && steps.publish_decision.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Validation-only run"
+            echo
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Publish requested: \`${{ inputs.publish_image }}\`"
+            echo "- Reason: ${{ steps.publish_decision.outputs.non_publish_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Canonical branch pushes and explicit manual publishes on that branch are allowed to refresh the registry tag.
       - name: Build and push
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: publish_image
         uses: docker/build-push-action@v7
         with:
           # The build context (https://docs.docker.com/build/building/context/), default is "."
@@ -47,4 +123,46 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/kino-data_service:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+
+      # Build a small release manifest so operators and later jobs can consume the exact deploy input.
+      - name: Write release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: release_manifest
+        run: |
+          python3 .github/scripts/write_image_release_manifest.py \
+            --service data-service \
+            --terraform-var TF_VAR_data_service_image_ref \
+            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --tag latest \
+            --digest "${{ steps.publish_image.outputs.digest }}" \
+            --git-revision "${{ github.sha }}" \
+            --git-ref "${{ github.ref }}" \
+            --git-commit-subject "$(git log -1 --pretty=%s)" \
+            --workflow "${{ github.workflow }}" \
+            --output release-manifest.json
+
+      # Surface the exact copy-paste line directly on the run summary page.
+      - name: Publish workflow summary
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        run: |
+          {
+            echo "## Published data-service image"
+            echo
+            echo "- Commit: \`${{ steps.release_manifest.outputs.short_git_revision }}\` ${{ steps.release_manifest.outputs.git_commit_subject }}"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Image ref: \`${{ steps.release_manifest.outputs.image_ref }}\`"
+            echo "- Terraform export:"
+            echo
+            echo '```bash'
+            echo "${{ steps.release_manifest.outputs.terraform_export }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the release manifest so operators can retrieve it without opening the raw step logs.
+      - name: Upload release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kino-data-service-release-manifest
+          path: release-manifest.json

--- a/.github/workflows/kino-generative-service.yaml
+++ b/.github/workflows/kino-generative-service.yaml
@@ -8,18 +8,72 @@ on:
       - master
     paths:
       - services/django-rest-framework/generative_service/**
+      - .github/workflows/kino-generative-service.yaml
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/django-rest-framework/generative_service/**
+      - .github/workflows/kino-generative-service.yaml
+  # Allows an operator to run the workflow manually from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      publish_image:
+        description: Publish the image from the selected ref. Publishing still requires refs/heads/master.
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: kino-generative_service
+  PUBLISH_REF: refs/heads/master
 
 # Creates a job ID (build) and declares the type of machine that the job should run on.
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
+      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
         uses: actions/checkout@v5
+
+      # Decide once whether this run is allowed to publish or should stay in validation mode.
+      - name: Decide publish mode
+        id: publish_decision
+        run: |
+          should_publish=false
+          non_publish_reason="This run will validate only."
+          publish_requested="$(python3 -c 'import json, sys; event = json.load(open(sys.argv[1])); print(str(event.get("inputs", {}).get("publish_image", "false")).lower())' "$GITHUB_EVENT_PATH")"
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" == "true" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" != "true" ]]; then
+            non_publish_reason="publish_image=false"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "${{ env.PUBLISH_REF }}" ]]; then
+            non_publish_reason="selected ref does not match ${{ env.PUBLISH_REF }}"
+          fi
+
+          {
+            echo "should_publish=$should_publish"
+            echo "non_publish_reason<<EOF"
+            echo "$non_publish_reason"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
-      # Signs in to Docker Hub, using the "Docker Login" action and your Docker Hub credentials.
+      # Docker Hub credentials are only needed when this run is actually allowed to publish the image.
       - name: Login to Docker Hub
+        if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -29,8 +83,36 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         
-      # Builds the container image and pushes it to the Docker Hub repository, using "Build and push Docker images".
+      # Pull requests and non-publishing manual runs only validate that the Dockerfile still builds.
+      - name: Build image for CI validation
+        if: steps.publish_decision.outputs.should_publish != 'true'
+        uses: docker/build-push-action@v7
+        with:
+          # The build context (https://docs.docker.com/build/building/context/), default is "."
+          context: services/django-rest-framework/generative_service/
+          # Filepath to the Dockerfile, default is "./Dockerfile"
+          file: services/django-rest-framework/generative_service/Dockerfile
+          # CI-only validation builds stay local to the runner.
+          push: false
+          # Local tag used only inside the CI runner.
+          tags: ${{ env.IMAGE_NAME }}:ci
+
+      # Manual runs that stay in validation mode still explain why no publish happened.
+      - name: Publish validation summary
+        if: github.event_name == 'workflow_dispatch' && steps.publish_decision.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Validation-only run"
+            echo
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Publish requested: \`${{ inputs.publish_image }}\`"
+            echo "- Reason: ${{ steps.publish_decision.outputs.non_publish_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Canonical branch pushes and explicit manual publishes on that branch are allowed to refresh the registry tag.
       - name: Build and push
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: publish_image
         uses: docker/build-push-action@v7
         with:
           # The build context (https://docs.docker.com/build/building/context/), default is "."
@@ -40,4 +122,46 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/kino-generative_service:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+
+      # Build a small release manifest so operators and later jobs can consume the exact deploy input.
+      - name: Write release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: release_manifest
+        run: |
+          python3 .github/scripts/write_image_release_manifest.py \
+            --service generative-service \
+            --terraform-var TF_VAR_generative_service_image_ref \
+            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --tag latest \
+            --digest "${{ steps.publish_image.outputs.digest }}" \
+            --git-revision "${{ github.sha }}" \
+            --git-ref "${{ github.ref }}" \
+            --git-commit-subject "$(git log -1 --pretty=%s)" \
+            --workflow "${{ github.workflow }}" \
+            --output release-manifest.json
+
+      # Surface the exact copy-paste line directly on the run summary page.
+      - name: Publish workflow summary
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        run: |
+          {
+            echo "## Published generative-service image"
+            echo
+            echo "- Commit: \`${{ steps.release_manifest.outputs.short_git_revision }}\` ${{ steps.release_manifest.outputs.git_commit_subject }}"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Image ref: \`${{ steps.release_manifest.outputs.image_ref }}\`"
+            echo "- Terraform export:"
+            echo
+            echo '```bash'
+            echo "${{ steps.release_manifest.outputs.terraform_export }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the release manifest so operators can retrieve it without opening the raw step logs.
+      - name: Upload release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kino-generative-service-release-manifest
+          path: release-manifest.json

--- a/.github/workflows/kino-jobs.yml
+++ b/.github/workflows/kino-jobs.yml
@@ -1,49 +1,169 @@
 # The name of this workflow.
 name: kino jobs ci
 
-# Specifies that this workflow should run on every push event for the branches in the list.
+# Run validation on pushes, PRs, and explicit manual invocations.
 on:
+  # Specifies that this workflow should run on every push event for the
+  # branches in the list, but only when the jobs code or this workflow changed.
   push:
     branches:
       - master
     paths:
       - jobs/**
-  # Specifies that this workflow should run on every pull request event targeting the branches in the list.
+      - .github/workflows/kino-jobs.yml
+  # Specifies that this workflow should run on every pull request event
+  # targeting the branches in the list, with the same path filter as `push`.
   pull_request:
     branches:
       - master
     paths:
       - jobs/**
+      - .github/workflows/kino-jobs.yml
+  # Allows an operator to run the workflow manually from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      publish_image:
+        description: Publish the runtime jobs image from the selected ref. Publishing still requires refs/heads/master.
+        required: true
+        default: false
+        type: boolean
 
-# Creates a job ID (build) and declares the type of machine that the job should run on.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Shared workflow variables keep repeated values in one place.
+env:
+  JOBS_DIR: jobs
+  RUNTIME_IMAGE_NAME: kino-jobs
+  RUNTIME_PUBLISH_REF: refs/heads/master
+  RUNTIME_IMAGE_TAG: kino-jobs:ci
+
+# This workflow keeps one job that validates the jobs Docker image on PRs and
+# non-publishing manual runs, and only publishes from merged `master` or an
+# explicit manual publish on `master`.
 jobs:
+  # Creates a job ID (`build`) and declares the type of machine that the job
+  # should run on.
   build:
     runs-on: ubuntu-latest
     steps:
-      # Checks out the repository on the build machine.
+      # Check out the repository on the runner.
       - name: Checkout
         uses: actions/checkout@v5
-      
-      # Signs in to Docker Hub, using the "Docker Login" action and your Docker Hub credentials.
+
+      # Decide once whether this run is allowed to publish or should stay in validation mode.
+      - name: Decide publish mode
+        id: publish_decision
+        run: |
+          should_publish=false
+          non_publish_reason="This run will validate only."
+          publish_requested="$(python3 -c 'import json, sys; event = json.load(open(sys.argv[1])); print(str(event.get("inputs", {}).get("publish_image", "false")).lower())' "$GITHUB_EVENT_PATH")"
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "${{ env.RUNTIME_PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" == "true" && "${{ github.ref }}" == "${{ env.RUNTIME_PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" != "true" ]]; then
+            non_publish_reason="publish_image=false"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "${{ env.RUNTIME_PUBLISH_REF }}" ]]; then
+            non_publish_reason="selected ref does not match ${{ env.RUNTIME_PUBLISH_REF }}"
+          fi
+
+          {
+            echo "should_publish=$should_publish"
+            echo "non_publish_reason<<EOF"
+            echo "$non_publish_reason"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Docker Hub credentials are only needed when this run is actually allowed to publish `kino-jobs:latest`.
       - name: Login to Docker Hub
+        if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
-      # Creates a BuildKit builder instance using the "Docker Setup Buildx" action.
+
+      # Buildx is used consistently for both CI-only image builds and published images.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        
-      # Builds the container image and pushes it to the Docker Hub repository, using "Build and push Docker images".
-      - name: Build and push
+
+      # PRs and non-publishing manual runs build the jobs image locally to validate the Dockerfile without mutating the registry.
+      - name: Build jobs image for CI
+        if: steps.publish_decision.outputs.should_publish != 'true'
         uses: docker/build-push-action@v7
         with:
-          # The build context (https://docs.docker.com/build/building/context/), default is "."
-          context: jobs/
-          # Filepath to the Dockerfile, default is "./Dockerfile"
+          # The build context is the `jobs/` directory.
+          context: ${{ env.JOBS_DIR }}
+          # Filepath to the Dockerfile relative to the repository root.
           file: jobs/Dockerfile
-          # Tells the action to upload the image to a registry after building it.
+          # CI-only validation builds stay local to the runner.
+          push: false
+          # Local tag used only inside the CI runner.
+          tags: ${{ env.RUNTIME_IMAGE_TAG }}
+
+      # Manual runs that stay in validation mode still explain why no runtime image publish happened.
+      - name: Publish validation summary
+        if: github.event_name == 'workflow_dispatch' && steps.publish_decision.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Validation-only run"
+            echo
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Publish requested: \`${{ inputs.publish_image }}\`"
+            echo "- Reason: ${{ steps.publish_decision.outputs.non_publish_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Canonical branch pushes and explicit manual publishes on that branch are allowed to refresh the mutable runtime tag.
+      - name: Build and push jobs image
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: publish_image
+        uses: docker/build-push-action@v7
+        with:
+          # The build context is the `jobs/` directory.
+          context: ${{ env.JOBS_DIR }}
+          # Filepath to the Dockerfile relative to the repository root.
+          file: jobs/Dockerfile
+          # Tells the action to upload the image to Docker Hub after building it.
           push: true
-          # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/kino-jobs:latest
+          # Tags specify where the pushed image should live.
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.RUNTIME_IMAGE_NAME }}:latest
+
+      # Build a small runtime release manifest so operators can copy the exact image ref later.
+      - name: Write runtime release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: runtime_release_manifest
+        run: |
+          python3 .github/scripts/write_image_release_manifest.py \
+            --service jobs-runtime \
+            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.RUNTIME_IMAGE_NAME }}" \
+            --tag latest \
+            --digest "${{ steps.publish_image.outputs.digest }}" \
+            --git-revision "${{ github.sha }}" \
+            --git-ref "${{ github.ref }}" \
+            --git-commit-subject "$(git log -1 --pretty=%s)" \
+            --workflow "${{ github.workflow }}" \
+            --output runtime-release-manifest.json
+
+      # Surface the runtime image ref directly on the run summary page.
+      - name: Publish runtime workflow summary
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        run: |
+          {
+            echo "## Published jobs runtime image"
+            echo
+            echo "- Commit: \`${{ steps.runtime_release_manifest.outputs.short_git_revision }}\` ${{ steps.runtime_release_manifest.outputs.git_commit_subject }}"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Image ref: \`${{ steps.runtime_release_manifest.outputs.image_ref }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the runtime release manifest separately so it cannot be confused with the dataset verification manifest.
+      - name: Upload runtime release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kino-jobs-runtime-release-manifest
+          path: runtime-release-manifest.json

--- a/.github/workflows/kino-trend-service.yaml
+++ b/.github/workflows/kino-trend-service.yaml
@@ -8,18 +8,72 @@ on:
       - master
     paths:
       - services/spring-boot/trend_service/**
+      - .github/workflows/kino-trend-service.yaml
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/spring-boot/trend_service/**
+      - .github/workflows/kino-trend-service.yaml
+  # Allows an operator to run the workflow manually from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      publish_image:
+        description: Publish the image from the selected ref. Publishing still requires refs/heads/master.
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: kino-trend_service
+  PUBLISH_REF: refs/heads/master
 
 # Creates a job ID (build) and declares the type of machine that the job should run on.
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
+      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
         uses: actions/checkout@v5
+
+      # Decide once whether this run is allowed to publish or should stay in validation mode.
+      - name: Decide publish mode
+        id: publish_decision
+        run: |
+          should_publish=false
+          non_publish_reason="This run will validate only."
+          publish_requested="$(python3 -c 'import json, sys; event = json.load(open(sys.argv[1])); print(str(event.get("inputs", {}).get("publish_image", "false")).lower())' "$GITHUB_EVENT_PATH")"
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" == "true" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" != "true" ]]; then
+            non_publish_reason="publish_image=false"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "${{ env.PUBLISH_REF }}" ]]; then
+            non_publish_reason="selected ref does not match ${{ env.PUBLISH_REF }}"
+          fi
+
+          {
+            echo "should_publish=$should_publish"
+            echo "non_publish_reason<<EOF"
+            echo "$non_publish_reason"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
-      # Signs in to Docker Hub, using the "Docker Login" action and your Docker Hub credentials.
+      # Docker Hub credentials are only needed when this run is actually allowed to publish the image.
       - name: Login to Docker Hub
+        if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -29,8 +83,36 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         
-      # Builds the container image and pushes it to the Docker Hub repository, using "Build and push Docker images".
+      # Pull requests and non-publishing manual runs only validate that the Dockerfile still builds.
+      - name: Build image for CI validation
+        if: steps.publish_decision.outputs.should_publish != 'true'
+        uses: docker/build-push-action@v7
+        with:
+          # The build context (https://docs.docker.com/build/building/context/), default is "."
+          context: services/spring-boot/trend_service/
+          # Filepath to the Dockerfile, default is "./Dockerfile"
+          file: services/spring-boot/trend_service/Dockerfile
+          # CI-only validation builds stay local to the runner.
+          push: false
+          # Local tag used only inside the CI runner.
+          tags: ${{ env.IMAGE_NAME }}:ci
+
+      # Manual runs that stay in validation mode still explain why no publish happened.
+      - name: Publish validation summary
+        if: github.event_name == 'workflow_dispatch' && steps.publish_decision.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Validation-only run"
+            echo
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Publish requested: \`${{ inputs.publish_image }}\`"
+            echo "- Reason: ${{ steps.publish_decision.outputs.non_publish_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Canonical branch pushes and explicit manual publishes on that branch are allowed to refresh the registry tag.
       - name: Build and push
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: publish_image
         uses: docker/build-push-action@v7
         with:
           # The build context (https://docs.docker.com/build/building/context/), default is "."
@@ -40,4 +122,46 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/kino-trend_service:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+
+      # Build a small release manifest so operators and later jobs can consume the exact deploy input.
+      - name: Write release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: release_manifest
+        run: |
+          python3 .github/scripts/write_image_release_manifest.py \
+            --service trend-service \
+            --terraform-var TF_VAR_trend_service_image_ref \
+            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --tag latest \
+            --digest "${{ steps.publish_image.outputs.digest }}" \
+            --git-revision "${{ github.sha }}" \
+            --git-ref "${{ github.ref }}" \
+            --git-commit-subject "$(git log -1 --pretty=%s)" \
+            --workflow "${{ github.workflow }}" \
+            --output release-manifest.json
+
+      # Surface the exact copy-paste line directly on the run summary page.
+      - name: Publish workflow summary
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        run: |
+          {
+            echo "## Published trend-service image"
+            echo
+            echo "- Commit: \`${{ steps.release_manifest.outputs.short_git_revision }}\` ${{ steps.release_manifest.outputs.git_commit_subject }}"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Image ref: \`${{ steps.release_manifest.outputs.image_ref }}\`"
+            echo "- Terraform export:"
+            echo
+            echo '```bash'
+            echo "${{ steps.release_manifest.outputs.terraform_export }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the release manifest so operators can retrieve it without opening the raw step logs.
+      - name: Upload release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kino-trend-service-release-manifest
+          path: release-manifest.json

--- a/.github/workflows/kino-ui.yaml
+++ b/.github/workflows/kino-ui.yaml
@@ -9,27 +9,74 @@ on:
       - master
     paths:
       - uis/react-ui/kino-ui/**
+      - .github/workflows/kino-ui.yaml
   # Specifies that this workflow should run on every pull request event targeting the branches in the list.
   pull_request:
     branches:
       - master
     paths:
       - uis/react-ui/kino-ui/**
+      - .github/workflows/kino-ui.yaml
   
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
+    inputs:
+      publish_image:
+        description: Publish the image from the selected ref. Publishing still requires refs/heads/master.
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: kino-ui
+  PUBLISH_REF: refs/heads/master
 
 # Creates a job ID (build) and declares the type of machine that the job should run on.
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
+      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
         uses: actions/checkout@v5
+
+      # Decide once whether this run is allowed to publish or should stay in validation mode.
+      - name: Decide publish mode
+        id: publish_decision
+        run: |
+          should_publish=false
+          non_publish_reason="This run will validate only."
+          publish_requested="$(python3 -c 'import json, sys; event = json.load(open(sys.argv[1])); print(str(event.get("inputs", {}).get("publish_image", "false")).lower())' "$GITHUB_EVENT_PATH")"
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" == "true" && "${{ github.ref }}" == "${{ env.PUBLISH_REF }}" ]]; then
+            should_publish=true
+            non_publish_reason=""
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$publish_requested" != "true" ]]; then
+            non_publish_reason="publish_image=false"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "${{ env.PUBLISH_REF }}" ]]; then
+            non_publish_reason="selected ref does not match ${{ env.PUBLISH_REF }}"
+          fi
+
+          {
+            echo "should_publish=$should_publish"
+            echo "non_publish_reason<<EOF"
+            echo "$non_publish_reason"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
-      # Signs in to Docker Hub, using the "Docker Login" action and your Docker Hub credentials.
+      # Docker Hub credentials are only needed when this run is actually allowed to publish the image.
       - name: Login to Docker Hub
+        if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -39,8 +86,36 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         
-      # Builds the container image and pushes it to the Docker Hub repository, using "Build and push Docker images".
+      # Pull requests and non-publishing manual runs only validate that the Dockerfile still builds.
+      - name: Build image for CI validation
+        if: steps.publish_decision.outputs.should_publish != 'true'
+        uses: docker/build-push-action@v7
+        with:
+          # The build context (https://docs.docker.com/build/building/context/), default is "."
+          context: uis/react-ui/kino-ui/
+          # Filepath to the Dockerfile, default is "./Dockerfile"
+          file: uis/react-ui/kino-ui/Dockerfile
+          # CI-only validation builds stay local to the runner.
+          push: false
+          # Local tag used only inside the CI runner.
+          tags: ${{ env.IMAGE_NAME }}:ci
+
+      # Manual runs that stay in validation mode still explain why no publish happened.
+      - name: Publish validation summary
+        if: github.event_name == 'workflow_dispatch' && steps.publish_decision.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Validation-only run"
+            echo
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Publish requested: \`${{ inputs.publish_image }}\`"
+            echo "- Reason: ${{ steps.publish_decision.outputs.non_publish_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Canonical branch pushes and explicit manual publishes on that branch are allowed to refresh the registry tag.
       - name: Build and push
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: publish_image
         uses: docker/build-push-action@v7
         with:
           # The build context (https://docs.docker.com/build/building/context/), default is "."
@@ -50,4 +125,46 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/kino-ui:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+
+      # Build a small release manifest so operators and later jobs can consume the exact deploy input.
+      - name: Write release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        id: release_manifest
+        run: |
+          python3 .github/scripts/write_image_release_manifest.py \
+            --service ui \
+            --terraform-var TF_VAR_ui_image_ref \
+            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --tag latest \
+            --digest "${{ steps.publish_image.outputs.digest }}" \
+            --git-revision "${{ github.sha }}" \
+            --git-ref "${{ github.ref }}" \
+            --git-commit-subject "$(git log -1 --pretty=%s)" \
+            --workflow "${{ github.workflow }}" \
+            --output release-manifest.json
+
+      # Surface the exact copy-paste line directly on the run summary page.
+      - name: Publish workflow summary
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        run: |
+          {
+            echo "## Published UI image"
+            echo
+            echo "- Commit: \`${{ steps.release_manifest.outputs.short_git_revision }}\` ${{ steps.release_manifest.outputs.git_commit_subject }}"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Image ref: \`${{ steps.release_manifest.outputs.image_ref }}\`"
+            echo "- Terraform export:"
+            echo
+            echo '```bash'
+            echo "${{ steps.release_manifest.outputs.terraform_export }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the release manifest so operators can retrieve it without opening the raw step logs.
+      - name: Upload release manifest
+        if: steps.publish_decision.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kino-ui-release-manifest
+          path: release-manifest.json


### PR DESCRIPTION
## Summary
- add guarded `workflow_dispatch` support to the publish workflows
- keep merged canonical-branch pushes as the default publish path
- add a helper for release-manifest handoff data

## Validation
- parsed modified workflow YAML locally
- ran `git diff --check`
- ran `terraform validate` in `orchestrators/k8s/terraform`
