### PR TITLE
Clean up GitHub Actions publish warnings (#44)

### DIFF
--- a/.github/workflows/dev-kino-auth-service.yaml
+++ b/.github/workflows/dev-kino-auth-service.yaml
@@ -31,9 +31,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
-      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
@@ -156,7 +153,7 @@ jobs:
       # Upload the release manifest so operators can retrieve it without opening the raw step logs.
       - name: Upload release manifest
         if: steps.publish_decision.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dev-kino-auth-service-release-manifest
           path: release-manifest.json

--- a/.github/workflows/dev-kino-ui.yaml
+++ b/.github/workflows/dev-kino-ui.yaml
@@ -32,9 +32,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
-      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
@@ -157,7 +154,7 @@ jobs:
       # Upload the release manifest so operators can retrieve it without opening the raw step logs.
       - name: Upload release manifest
         if: steps.publish_decision.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dev-kino-ui-release-manifest
           path: release-manifest.json

--- a/.github/workflows/kino-agent-service.yaml
+++ b/.github/workflows/kino-agent-service.yaml
@@ -82,9 +82,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
-    outputs:
-      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
-      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -198,7 +195,7 @@ jobs:
       # Upload the release manifest so operators can retrieve it without opening the raw step logs.
       - name: Upload release manifest
         if: steps.publish_decision.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kino-agent-service-release-manifest
           path: release-manifest.json

--- a/.github/workflows/kino-auth-service.yaml
+++ b/.github/workflows/kino-auth-service.yaml
@@ -35,9 +35,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
-      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
@@ -160,7 +157,7 @@ jobs:
       # Upload the release manifest so operators can retrieve it without opening the raw step logs.
       - name: Upload release manifest
         if: steps.publish_decision.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kino-auth-service-release-manifest
           path: release-manifest.json

--- a/.github/workflows/kino-data-service.yaml
+++ b/.github/workflows/kino-data-service.yaml
@@ -37,9 +37,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
-      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
@@ -162,7 +159,7 @@ jobs:
       # Upload the release manifest so operators can retrieve it without opening the raw step logs.
       - name: Upload release manifest
         if: steps.publish_decision.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kino-data-service-release-manifest
           path: release-manifest.json

--- a/.github/workflows/kino-generative-service.yaml
+++ b/.github/workflows/kino-generative-service.yaml
@@ -36,9 +36,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
-      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
@@ -161,7 +158,7 @@ jobs:
       # Upload the release manifest so operators can retrieve it without opening the raw step logs.
       - name: Upload release manifest
         if: steps.publish_decision.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kino-generative-service-release-manifest
           path: release-manifest.json

--- a/.github/workflows/kino-jobs.yml
+++ b/.github/workflows/kino-jobs.yml
@@ -163,7 +163,7 @@ jobs:
       # Upload the runtime release manifest separately so it cannot be confused with the dataset verification manifest.
       - name: Upload runtime release manifest
         if: steps.publish_decision.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kino-jobs-runtime-release-manifest
           path: runtime-release-manifest.json

--- a/.github/workflows/kino-trend-service.yaml
+++ b/.github/workflows/kino-trend-service.yaml
@@ -36,9 +36,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
-      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
@@ -161,7 +158,7 @@ jobs:
       # Upload the release manifest so operators can retrieve it without opening the raw step logs.
       - name: Upload release manifest
         if: steps.publish_decision.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kino-trend-service-release-manifest
           path: release-manifest.json

--- a/.github/workflows/kino-ui.yaml
+++ b/.github/workflows/kino-ui.yaml
@@ -39,9 +39,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      image_ref: ${{ steps.release_manifest.outputs.image_ref }}
-      terraform_export: ${{ steps.release_manifest.outputs.terraform_export }}
     steps:
       # Checks out the repository on the build machine.
       - name: Checkout
@@ -164,7 +161,7 @@ jobs:
       # Upload the release manifest so operators can retrieve it without opening the raw step logs.
       - name: Upload release manifest
         if: steps.publish_decision.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kino-ui-release-manifest
           path: release-manifest.json

--- a/services/spring-boot/auth_service/Dockerfile
+++ b/services/spring-boot/auth_service/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Gradle image from the openjdk Docker Hub page
-FROM gradle:8.4-jdk17 as builder
+FROM gradle:8.4-jdk17 AS builder
 
 # Add Maintainer Info
 LABEL maintainer="eido.askayo@gmail.com"

--- a/services/spring-boot/data_service/Dockerfile
+++ b/services/spring-boot/data_service/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Gradle image from the openjdk Docker Hub page
-FROM gradle:8.4-jdk17 as builder
+FROM gradle:8.4-jdk17 AS builder
 
 # Add Maintainer Info
 LABEL maintainer="eido.askayo@gmail.com"

--- a/services/spring-boot/trend_service/Dockerfile
+++ b/services/spring-boot/trend_service/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Gradle image from the openjdk Docker Hub page
-FROM gradle:7.4-jdk17 as builder
+FROM gradle:7.4-jdk17 AS builder
 
 # Add Maintainer Info
 LABEL maintainer="eido.askayo@gmail.com"


### PR DESCRIPTION
## Summary
- upgrade publish workflow artifact uploads from `actions/upload-artifact@v4` to `@v6`
- remove unused workflow job outputs that trigger GitHub secret-like output warnings
- fix Dockerfile stage alias casing warnings in Spring Boot service images

## Validation
- parsed workflow YAML locally
- ran `git diff --check`
- verified no remaining `upload-artifact@v4` or lowercase `FROM ... as` matches in the touched paths