### PR TITLE
Use GitHub Actions variable for Docker Hub username (#46)

### DIFF
--- a/.github/workflows/dev-kino-auth-service.yaml
+++ b/.github/workflows/dev-kino-auth-service.yaml
@@ -68,7 +68,7 @@ jobs:
         if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       # Creates a BuildKit builder instance using the "Docker Setup Buildx" action.
@@ -114,7 +114,7 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.PUBLISH_TAG }}
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.PUBLISH_TAG }}
 
       # Build a small release manifest so operators and later jobs can consume the exact deploy input.
       - name: Write release manifest
@@ -124,7 +124,7 @@ jobs:
           python3 .github/scripts/write_image_release_manifest.py \
             --service dev-auth-service \
             --terraform-var TF_VAR_auth_service_image_ref \
-            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --repository "${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
             --tag "${{ env.PUBLISH_TAG }}" \
             --digest "${{ steps.publish_image.outputs.digest }}" \
             --git-revision "${{ github.sha }}" \

--- a/.github/workflows/dev-kino-ui.yaml
+++ b/.github/workflows/dev-kino-ui.yaml
@@ -69,7 +69,7 @@ jobs:
         if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       # Creates a BuildKit builder instance using the "Docker Setup Buildx" action.
@@ -115,7 +115,7 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.PUBLISH_TAG }}
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.PUBLISH_TAG }}
 
       # Build a small release manifest so operators and later jobs can consume the exact deploy input.
       - name: Write release manifest
@@ -125,7 +125,7 @@ jobs:
           python3 .github/scripts/write_image_release_manifest.py \
             --service dev-ui \
             --terraform-var TF_VAR_ui_image_ref \
-            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --repository "${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
             --tag "${{ env.PUBLISH_TAG }}" \
             --digest "${{ steps.publish_image.outputs.digest }}" \
             --git-revision "${{ github.sha }}" \

--- a/.github/workflows/kino-agent-service.yaml
+++ b/.github/workflows/kino-agent-service.yaml
@@ -118,7 +118,7 @@ jobs:
         if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Buildx is used consistently for both CI-only image builds and published images.
@@ -156,7 +156,7 @@ jobs:
           context: services/langgraph/agent_service
           file: services/langgraph/agent_service/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
 
       # Build a small release manifest so operators and later jobs can consume the exact deploy input.
       - name: Write release manifest
@@ -166,7 +166,7 @@ jobs:
           python3 .github/scripts/write_image_release_manifest.py \
             --service agent-service \
             --terraform-var TF_VAR_agent_service_image_ref \
-            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --repository "${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
             --tag latest \
             --digest "${{ steps.publish_image.outputs.digest }}" \
             --git-revision "${{ github.sha }}" \

--- a/.github/workflows/kino-auth-service.yaml
+++ b/.github/workflows/kino-auth-service.yaml
@@ -72,7 +72,7 @@ jobs:
         if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       # Creates a BuildKit builder instance using the "Docker Setup Buildx" action.
@@ -118,7 +118,7 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
 
       # Build a small release manifest so operators and later jobs can consume the exact deploy input.
       - name: Write release manifest
@@ -128,7 +128,7 @@ jobs:
           python3 .github/scripts/write_image_release_manifest.py \
             --service auth-service \
             --terraform-var TF_VAR_auth_service_image_ref \
-            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --repository "${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
             --tag latest \
             --digest "${{ steps.publish_image.outputs.digest }}" \
             --git-revision "${{ github.sha }}" \

--- a/.github/workflows/kino-data-service.yaml
+++ b/.github/workflows/kino-data-service.yaml
@@ -74,7 +74,7 @@ jobs:
         if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       # Creates a BuildKit builder instance using the "Docker Setup Buildx" action.
@@ -120,7 +120,7 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
 
       # Build a small release manifest so operators and later jobs can consume the exact deploy input.
       - name: Write release manifest
@@ -130,7 +130,7 @@ jobs:
           python3 .github/scripts/write_image_release_manifest.py \
             --service data-service \
             --terraform-var TF_VAR_data_service_image_ref \
-            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --repository "${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
             --tag latest \
             --digest "${{ steps.publish_image.outputs.digest }}" \
             --git-revision "${{ github.sha }}" \

--- a/.github/workflows/kino-generative-service.yaml
+++ b/.github/workflows/kino-generative-service.yaml
@@ -73,7 +73,7 @@ jobs:
         if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       # Creates a BuildKit builder instance using the "Docker Setup Buildx" action.
@@ -119,7 +119,7 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
 
       # Build a small release manifest so operators and later jobs can consume the exact deploy input.
       - name: Write release manifest
@@ -129,7 +129,7 @@ jobs:
           python3 .github/scripts/write_image_release_manifest.py \
             --service generative-service \
             --terraform-var TF_VAR_generative_service_image_ref \
-            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --repository "${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
             --tag latest \
             --digest "${{ steps.publish_image.outputs.digest }}" \
             --git-revision "${{ github.sha }}" \

--- a/.github/workflows/kino-jobs.yml
+++ b/.github/workflows/kino-jobs.yml
@@ -84,7 +84,7 @@ jobs:
         if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Buildx is used consistently for both CI-only image builds and published images.
@@ -130,7 +130,7 @@ jobs:
           # Tells the action to upload the image to Docker Hub after building it.
           push: true
           # Tags specify where the pushed image should live.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.RUNTIME_IMAGE_NAME }}:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.RUNTIME_IMAGE_NAME }}:latest
 
       # Build a small runtime release manifest so operators can copy the exact image ref later.
       - name: Write runtime release manifest
@@ -139,7 +139,7 @@ jobs:
         run: |
           python3 .github/scripts/write_image_release_manifest.py \
             --service jobs-runtime \
-            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.RUNTIME_IMAGE_NAME }}" \
+            --repository "${{ vars.DOCKERHUB_USERNAME }}/${{ env.RUNTIME_IMAGE_NAME }}" \
             --tag latest \
             --digest "${{ steps.publish_image.outputs.digest }}" \
             --git-revision "${{ github.sha }}" \

--- a/.github/workflows/kino-trend-service.yaml
+++ b/.github/workflows/kino-trend-service.yaml
@@ -73,7 +73,7 @@ jobs:
         if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       # Creates a BuildKit builder instance using the "Docker Setup Buildx" action.
@@ -119,7 +119,7 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
 
       # Build a small release manifest so operators and later jobs can consume the exact deploy input.
       - name: Write release manifest
@@ -129,7 +129,7 @@ jobs:
           python3 .github/scripts/write_image_release_manifest.py \
             --service trend-service \
             --terraform-var TF_VAR_trend_service_image_ref \
-            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --repository "${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
             --tag latest \
             --digest "${{ steps.publish_image.outputs.digest }}" \
             --git-revision "${{ github.sha }}" \

--- a/.github/workflows/kino-ui.yaml
+++ b/.github/workflows/kino-ui.yaml
@@ -76,7 +76,7 @@ jobs:
         if: steps.publish_decision.outputs.should_publish == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       # Creates a BuildKit builder instance using the "Docker Setup Buildx" action.
@@ -122,7 +122,7 @@ jobs:
           # Tells the action to upload the image to a registry after building it.
           push: true
           # Tags that specify where to push the image.
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
 
       # Build a small release manifest so operators and later jobs can consume the exact deploy input.
       - name: Write release manifest
@@ -132,7 +132,7 @@ jobs:
           python3 .github/scripts/write_image_release_manifest.py \
             --service ui \
             --terraform-var TF_VAR_ui_image_ref \
-            --repository "${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
+            --repository "${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}" \
             --tag latest \
             --digest "${{ steps.publish_image.outputs.digest }}" \
             --git-revision "${{ github.sha }}" \


### PR DESCRIPTION
## Summary
- switch GitHub Actions workflows from `secrets.DOCKERHUB_USERNAME` to `vars.DOCKERHUB_USERNAME`
- keep `DOCKERHUB_TOKEN` in secrets
- preserve existing publish behavior while avoiding unnecessary masking of the username in workflow summaries

## Validation
- parsed workflow YAML locally
- ran `git diff --check`
- verified no remaining `secrets.DOCKERHUB_USERNAME` references in `.github/workflows`